### PR TITLE
Add DNS variables to platform-test tfvars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ set-azure-account:
 	az account set -s ${AZ_SUBSCRIPTION}
 
 terraform-init: set-azure-account
-	terraform -chdir=cluster/terraform init -reconfigure \
+	terraform -chdir=cluster/terraform init -reconfigure -upgrade \
 		-backend-config=resource_group_name=${RESOURCE_GROUP_NAME} \
 		-backend-config=storage_account_name=${STORAGE_ACCOUNT_NAME} \
 		-backend-config=key=${ENVIRONMENT}.tfstate
@@ -71,7 +71,7 @@ domain-azure-resources: set-azure-account set-azure-template-tag set-azure-resou
 			"keyVaultName=${KEYVAULT_NAME}" ${WHAT_IF}
 
 domains-infra-init: set-azure-account
-	terraform -chdir=custom_domains/terraform/infrastructure init -reconfigure \
+	terraform -chdir=custom_domains/terraform/infrastructure init -reconfigure -upgrade \
 		-backend-config=workspace_variables/${DOMAINS_ID}_backend.tfvars
 
 domains-infra-plan: domains-infra-init

--- a/cluster/terraform/variables.tf
+++ b/cluster/terraform/variables.tf
@@ -7,7 +7,11 @@ variable "environment" {}
 variable "resource_prefix" {}
 variable "resource_group_name" {}
 variable "cluster_dns_resource_group_name" { default = null }
-variable "cluster_dns_zone" { default = null }
+variable "cluster_dns_zone" {
+  description = "The name of the DNS zone containing A records pointing to the ingress public IPs.  This is only used for the development environment"
+  default     = null
+  type        = string
+}
 variable "cluster_kv" {}
 variable "config" {}
 variable "ingress_cert_name" {

--- a/custom_domains/terraform/infrastructure/.terraform.lock.hcl
+++ b/custom_domains/terraform/infrastructure/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.25.0"
   constraints = "3.25.0"
   hashes = [
+    "h1:cGOXuhIvBw18lekG5eWhco7UFPC3XwgpgTSs5OLesDA=",
     "h1:nG2VCJ16Sl6slG004l1xZBOus7EOx6FFHPnaXl7eq1U=",
     "zh:35ae77914a6280592a199a56c75a5f953cb5553f4416e50f4d4f47732eeb8d67",
     "zh:3e2562a26b047e314a9fd28ee16ab460ce412fe00ed17583f3abfcc9c6998e0f",

--- a/custom_domains/terraform/infrastructure/main.tf
+++ b/custom_domains/terraform/infrastructure/main.tf
@@ -1,5 +1,5 @@
 module "domains_infrastructure" {
-  source      = "git::https://github.com/DFE-Digital/terraform-modules.git//domains/infrastructure"
+  source      = "git::https://github.com/DFE-Digital/terraform-modules.git//domains/infrastructure?ref=0.5.0"
   hosted_zone = var.hosted_zone
   tags        = var.tags
 }
@@ -12,4 +12,9 @@ resource "azurerm_dns_ns_record" "dev_ns_record" {
   resource_group_name = var.hosted_zone[keys(var.hosted_zone)[0]].resource_group_name
   records             = var.delegation_ns
   ttl                 = 300
+}
+
+module "dns_records" {
+  source      = "git::https://github.com/DFE-Digital/terraform-modules.git//dns/records?ref=0.5.0"
+  hosted_zone = var.hosted_zone
 }

--- a/custom_domains/terraform/infrastructure/workspace_variables/tscp.tfvars.json
+++ b/custom_domains/terraform/infrastructure/workspace_variables/tscp.tfvars.json
@@ -2,7 +2,12 @@
     "hosted_zone": {
         "teacherservices.cloud": {
             "resource_group_name": "s189p01-tscdomains-rg",
-            "front_door_name": "s189p01-tscdomains-fd"
+            "front_door_name": "s189p01-tscdomains-fd",
+            "a-records": {
+                "*.platform-test": {
+                    "target": "20.108.239.230"
+                }
+            }
         }
     },
     "tags": {


### PR DESCRIPTION
### Context

We require a wildcarded DNS record for each cluster

### Changes proposed in this PR

- Modify terraform to support adding wildcarded record
- Add config for platform-test

### Guidance for review

This change will be applied by running `make prod-domain domains-infra-apply` locally.  Prior to that please review changes, they can be tested by running `make prod-domain domains-infra-plan` locally.