### PR TITLE
Add dns test to production

### DIFF
--- a/custom_domains/terraform/infrastructure/workspace_variables/tscp.tfvars.json
+++ b/custom_domains/terraform/infrastructure/workspace_variables/tscp.tfvars.json
@@ -6,6 +6,9 @@
             "a-records": {
                 "*.platform-test": {
                     "target": "20.108.239.230"
+                },
+                "*.test": {
+                    "target": "20.26.8.160"
                 }
             }
         }


### PR DESCRIPTION
### Context

We require a wildcarded DNS record for each cluster

### Changes proposed in this PR

- Add config for test

### Guidance for review

This change will be applied by running `make prod-domain domains-infra-apply` locally.  Prior to that please review changes, they can be tested by running `make prod-domain domains-infra-plan` locally.