### PR TITLE
Pre-provision vNet for AKS with option to add additional subnets

### DIFF
--- a/.github/workflows/deploy-cluster.yml
+++ b/.github/workflows/deploy-cluster.yml
@@ -36,6 +36,7 @@ jobs:
     needs: [validate-terraform]
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         environment: [platform-test, test]
     steps:

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,12 @@ dev-domain:
 set-azure-account:
 	az account set -s ${AZ_SUBSCRIPTION}
 
-terraform-init: set-azure-account
+terraform-init: set-azure-account set-azure-resource-group-tags
 	terraform -chdir=cluster/terraform init -reconfigure -upgrade \
 		-backend-config=resource_group_name=${RESOURCE_GROUP_NAME} \
 		-backend-config=storage_account_name=${STORAGE_ACCOUNT_NAME} \
 		-backend-config=key=${ENVIRONMENT}.tfstate
-	$(eval TF_VARS=-var environment=${ENVIRONMENT} -var resource_group_name=${RESOURCE_GROUP_NAME} -var resource_prefix=${RESOURCE_PREFIX} -var config=${CONFIG})
+	$(eval TF_VARS=-var environment=${ENVIRONMENT} -var resource_group_name=${RESOURCE_GROUP_NAME} -var resource_prefix=${RESOURCE_PREFIX} -var config=${CONFIG} -var azure_tags='${RG_TAGS}')
 
 terraform-plan: terraform-init
 	terraform -chdir=cluster/terraform plan -var-file config/${CONFIG}.tfvars.json ${TF_VARS}

--- a/cluster/terraform/main.tf
+++ b/cluster/terraform/main.tf
@@ -2,6 +2,44 @@ data "azurerm_resource_group" "cluster" {
   name = var.resource_group_name
 }
 
+resource "azurerm_virtual_network" "vnet" {
+  name                = local.vnet_name
+  location            = data.azurerm_resource_group.cluster.location
+  resource_group_name = data.azurerm_resource_group.cluster.name
+  address_space       = ["10.0.0.0/12"]
+
+  lifecycle { ignore_changes = [tags] }
+}
+
+resource "azurerm_subnet" "aks-subnet" {
+  name                 = "aks-snet"
+  resource_group_name  = data.azurerm_resource_group.cluster.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  # by default AKS uses 10.0.0.0/16 for it's internal service CIDR range, this cannot overlap with the external subnet so we use 10.1.0.0/16
+  address_prefixes = ["10.1.0.0/16"]
+}
+
+resource "azurerm_subnet" "backing-service-subnets" {
+  for_each = local.subnets
+
+  name                 = each.key
+  resource_group_name  = data.azurerm_resource_group.cluster.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = [each.value.cidr_range]
+
+  dynamic "delegation" {
+    for_each = each.value.delegations
+
+    content {
+      name = delegation.key
+      service_delegation {
+        name    = delegation.value["name"]
+        actions = delegation.value["actions"]
+      }
+    }
+  }
+}
+
 resource "azurerm_kubernetes_cluster" "main" {
   name                = local.cluster_name
   location            = data.azurerm_resource_group.cluster.location
@@ -10,9 +48,10 @@ resource "azurerm_kubernetes_cluster" "main" {
   dns_prefix          = local.dns_prefix
 
   default_node_pool {
-    name       = "default"
-    node_count = 1
-    vm_size    = "Standard_D2_v2"
+    name           = "default"
+    node_count     = 1
+    vm_size        = "Standard_D2_v2"
+    vnet_subnet_id = azurerm_subnet.aks-subnet.id
   }
 
   identity {
@@ -20,4 +59,30 @@ resource "azurerm_kubernetes_cluster" "main" {
   }
 
   lifecycle { ignore_changes = [tags] }
+}
+
+resource "azurerm_private_dns_zone" "backing-services-dns-zones" {
+  for_each = local.subnets
+
+  name                = var.environment == var.config ? "${var.config}.internal.postgres.database.azure.com" : "${var.environment}.${var.config}.internal.postgres.database.azure.com"
+  resource_group_name = data.azurerm_resource_group.cluster.name
+
+  lifecycle { ignore_changes = [tags] }
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "dns-vnet-links" {
+  for_each = resource.azurerm_private_dns_zone.backing-services-dns-zones
+
+  name                  = each.value.name
+  resource_group_name   = data.azurerm_resource_group.cluster.name
+  private_dns_zone_name = each.value.name
+  virtual_network_id    = azurerm_virtual_network.vnet.id
+
+  lifecycle { ignore_changes = [tags] }
+}
+
+resource "azurerm_resource_group" "backing_services_group" {
+  name     = local.backing_services_resource_group_name
+  location = data.azurerm_resource_group.cluster.location
+  tags     = jsondecode(var.azure_tags)
 }


### PR DESCRIPTION
### Context

In order to securely manage connectivity to Azure resources outside of AKS we need to control the network it's attached.  To avoid tightly coupling external resources to the cluster we need to manage that network independently of AKS.

### Changes proposed in this PR

- Adds a vNet with a default subnet that is connected to the AKS cluster default node pool
- Adds the option to create additional subnets with optional delegations
- Adds the option to create a private DNS zone for each subnet that is linked to the subnet

Other things to note:
- To support deploying optional subnets with DNS zones into the development environment I've had to conditionally set the name of those zones.  That logic now exists in two separate places in the terraform, this might become increasingly difficult to maintain over time and cause errors, eg breaking network connections to the databases as I did whilst testing this change

### Guidance to review

Run `make development terraform-apply ENVIRONMENT=clusterX` to create a development cluster.

