### PR TITLE
Updated A record values in tscp DNS config

### DIFF
--- a/custom_domains/terraform/infrastructure/workspace_variables/tscp.tfvars.json
+++ b/custom_domains/terraform/infrastructure/workspace_variables/tscp.tfvars.json
@@ -5,10 +5,13 @@
             "front_door_name": "s189p01-tscdomains-fd",
             "a-records": {
                 "*.platform-test": {
-                    "target": "20.108.239.230"
+                    "target": "51.142.214.68"
                 },
                 "*.test": {
-                    "target": "20.108.114.61"
+                    "target": "20.108.195.10"
+                },
+                "*": {
+                    "target": "20.90.142.95"
                 }
             }
         }


### PR DESCRIPTION
### Context

Clusters have been destroyed and redeployed, new public IPs were created as a result

### Changes proposed in this PR

- Update A record DNS config in tscp.tfvars.json
- Add missing record for production (wildcard at root)

### Guidance to review

- Check terraform is valid with `make production domains-infra-plan DOMAINS_ID=tscp`
- Check that correct IP addresses are used
- Check that new config is correct for production