### PR TITLE
add 'applications' node pool

### DIFF
--- a/cluster/terraform/config/development.tfvars.json
+++ b/cluster/terraform/config/development.tfvars.json
@@ -8,5 +8,14 @@
   ],
   "cluster_dns_resource_group_name": "s189d01-tscdomains-rg",
   "cluster_dns_zone": "development.teacherservices.cloud",
-  "cluster_kv": "s189d01-tsc2-dv-kv"
+  "cluster_kv": "s189d01-tsc2-dv-kv",
+  "default_node_pool": {
+    "node_count": 1
+  },
+  "node_pools": {
+    "applications": {
+      "min_count": 1,
+      "max_count": 2
+    }
+  }
 }

--- a/cluster/terraform/config/platform-test.tfvars.json
+++ b/cluster/terraform/config/platform-test.tfvars.json
@@ -6,5 +6,14 @@
       "staging",
       "test"
     ],
-    "cluster_kv": "s189t01-tsc-pt-kv"
+    "cluster_kv": "s189t01-tsc-pt-kv",
+    "default_node_pool": {
+      "node_count": 2
+    },
+    "node_pools": {
+      "applications": {
+        "min_count": 2,
+        "max_count": 6
+      }
+    }
   }

--- a/cluster/terraform/config/production.tfvars.json
+++ b/cluster/terraform/config/production.tfvars.json
@@ -1,5 +1,14 @@
 {
   "cip_tenant": true,
   "namespaces": ["bat-production"],
-  "cluster_kv": "s189p01-tsc-pd-kv"
+  "cluster_kv": "s189p01-tsc-pd-kv",
+  "default_node_pool": {
+    "node_count": 3
+  },
+  "node_pools": {
+    "applications": {
+      "min_count": 3,
+      "max_count": 6
+    }
+  }
 }

--- a/cluster/terraform/config/test.tfvars.json
+++ b/cluster/terraform/config/test.tfvars.json
@@ -1,6 +1,19 @@
 {
   "cip_tenant": true,
-  "namespaces": ["development", "bat-qa", "bat-staging"],
+  "namespaces": [
+    "development",
+    "bat-qa",
+    "bat-staging"
+  ],
   "cluster_kv": "s189t01-tsc-ts-kv",
-  "ingress_cert_name": "test-teacherservices-cloud-2"
+  "ingress_cert_name": "test-teacherservices-cloud-2",
+  "default_node_pool": {
+    "node_count": 2
+  },
+  "node_pools": {
+    "applications": {
+      "min_count": 2,
+      "max_count": 6
+    }
+  }
 }

--- a/cluster/terraform/variables.tf
+++ b/cluster/terraform/variables.tf
@@ -23,6 +23,8 @@ variable "ingress_cert_name" {
 # Set in config json file
 variable "cip_tenant" { type = bool }
 variable "namespaces" {}
+variable "default_node_pool" { type = map(any) }
+variable "node_pools" { type = map(any) }
 
 locals {
   azure_credentials                    = try(jsondecode(var.azure_sp_credentials_json), null)
@@ -71,4 +73,5 @@ locals {
   privatelink_dns_zone_names = [
     "privatelink.redis.cache.windows.net"
   ]
+  uk_south_availability_zones = ["1", "2", "3"]
 }


### PR DESCRIPTION
## Context
Added `applications` node pool with values to be inserted from each environments tfvars
Some values have been hard coded as they should be true regardless of environment.
Created new local variable for uk south availability zones (1,2,3).

## Changes proposed in this pull request
Create a new auto scaling node pool named `applications`
Ensure the default node pool can stretch across all availability zones within uk south

## Guidance to review
Successful build: < to link here >

## Link to Trello card
https://trello.com/c/12D34eAJ/107-run-apply-build-with-secrets-from-s189

## Things to check

- [ ] If the code removes any existing feature flags, a data migration has also been added to delete the entry from the database
- [ ] This code does not rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] If this code adds a column to the DB, decide whether it needs to be in analytics yml file or analytics blocklist
- [ ] API release notes have been updated if necessary
- [ ] Required environment variables have been updated [added to the Azure KeyVault](/docs/environment-variables.md#deploy-pipeline)
