### PR TITLE
[195] Update ingress DNS for all clusters

### DIFF
--- a/custom_domains/terraform/infrastructure/workspace_variables/tscp.tfvars.json
+++ b/custom_domains/terraform/infrastructure/workspace_variables/tscp.tfvars.json
@@ -5,13 +5,13 @@
             "front_door_name": "s189p01-tscdomains-fd",
             "a-records": {
                 "*.platform-test": {
-                    "target": "51.142.214.68"
+                    "target": "20.49.212.39"
                 },
                 "*.test": {
-                    "target": "20.108.195.10"
+                    "target": "20.49.208.228"
                 },
                 "*": {
-                    "target": "20.90.142.95"
+                    "target": "20.49.225.59"
                 }
             }
         }


### PR DESCRIPTION
## What
Following the clusters rebuild, a new ingress IP was allocated for each cluster. The domains must be updated.

## How to review
The change has already been applied. You should see the nginx empty page: https://aaa.teacherservices.cloud/