### PR TITLE
Increase nginx proxy-buffer-size to 8k

### DIFF
--- a/cluster/terraform/kubernetes-config/ingress_controller.tf
+++ b/cluster/terraform/kubernetes-config/ingress_controller.tf
@@ -14,4 +14,9 @@ resource "helm_release" "ingress-nginx" {
     name  = "controller.extraArgs.default-ssl-certificate"
     value = "default/cert-secret"
   }
+
+  set {
+    name  = "controller.config.proxy-buffer-size"
+    value = "8k"
+  }
 }


### PR DESCRIPTION

**Context**

Increase nginx-ingress proxy-buffer-size from 4k to 8k
This fixes an issue with DSI where the request is larger than 4k

**Changes proposed in this pull request**

Add setting to config map for the nginx-ingress

**Guidance to review**

deploy dev cluster then a review app
Login to the nginx instance and grep -i buffer nginx.conf

or check dev cluster5 

Also manually changed for qa2.service domain in the test cluster,
but that may get overwritten

