### PR TITLE
Allow passing args to konduit psql

### DIFF
--- a/scripts/konduit.sh
+++ b/scripts/konduit.sh
@@ -169,7 +169,7 @@ open_tunnels() {
 
 run_psql() {
    if [ "$Inputfile" = "" ]; then
-      psql -d "$DB_URL" --no-password
+      psql -d "$DB_URL" --no-password $OTHERARGS
    elif [ "$CompressedInput" = "" ]; then
       psql -d "$DB_URL" --no-password <"$Inputfile"
    else


### PR DESCRIPTION
**Context**

Update konduit.sh script to allow passing sql commands to psql

**Changes proposed in this pull request**

Add $OTHERARGS to psql

**Guidance to review**

./konduit.sh apply-qa -- psql -c '\dt'
