### PR TITLE
Add quotes to OTHERARGS var

### DIFF
--- a/scripts/konduit.sh
+++ b/scripts/konduit.sh
@@ -182,7 +182,7 @@ run_pgdump() {
       echo "ERROR: Must supply arguments for pg_dump"
       exit
    fi
-   pg_dump -d "$DB_URL" --no-password $OTHERARGS
+   pg_dump -d "$DB_URL" --no-password "${OTHERARGS}"
 }
 
 cleanup() {


### PR DESCRIPTION
Add quotes to the $OTHERARGS variable,
required for commands to be run successfully