### PR TITLE
Added cluster and node upgrade parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,4 +127,6 @@ and the prod zone updated.
 The teacherservices.cloud domain is created in route53 and owned by infra-ops. So if the production zone NS records are changed for any reason, then contact infra-ops to update the domain.
 
 ## Links
+- [AKS upgrade](documentation/aks-upgrade.md)
+- [Node pool migration](documentation/node-pool-migration.md)
 - [Retrieving Log Analytics Data with KQL for AKS Clusters](documentation/aks-logs.md)

--- a/cluster/terraform_aks_cluster/config/development.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/development.tfvars.json
@@ -1,7 +1,9 @@
 {
   "cip_tenant": true,
+  "kubernetes_version": "1.24.9",
   "default_node_pool": {
-    "node_count": 1
+    "node_count": 1,
+    "orchestrator_version": "1.24.9"
   },
   "node_pools": {
     "apps1": {
@@ -9,7 +11,8 @@
       "max_count": 2,
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
-      }
+      },
+      "orchestrator_version": "1.24.9"
     }
   }
 }

--- a/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
@@ -1,7 +1,9 @@
 {
   "cip_tenant": true,
+  "kubernetes_version": "1.24.9",
   "default_node_pool": {
-    "node_count": 2
+    "node_count": 2,
+    "orchestrator_version": "1.24.9"
   },
   "node_pools": {
     "apps1": {
@@ -9,7 +11,8 @@
       "max_count": 6,
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
-      }
+      },
+      "orchestrator_version": "1.24.9"
     }
   }
 }

--- a/cluster/terraform_aks_cluster/config/production.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/production.tfvars.json
@@ -1,7 +1,9 @@
 {
   "cip_tenant": true,
+  "kubernetes_version": "1.24.9",
   "default_node_pool": {
-    "node_count": 3
+    "node_count": 3,
+    "orchestrator_version": "1.24.9"
   },
   "node_pools": {
     "apps1": {
@@ -10,7 +12,8 @@
       "vm_size": "Standard_E4ads_v5",
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
-      }
+      },
+      "orchestrator_version": "1.24.9"
     }
   }
 }

--- a/cluster/terraform_aks_cluster/config/test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/test.tfvars.json
@@ -1,7 +1,9 @@
 {
   "cip_tenant": true,
+  "kubernetes_version": "1.24.9",
   "default_node_pool": {
-    "node_count": 2
+    "node_count": 2,
+    "orchestrator_version": "1.24.9"
   },
   "node_pools": {
     "apps1": {
@@ -10,7 +12,8 @@
       "vm_size": "Standard_E4ads_v5",
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
-      }
+      },
+      "orchestrator_version": "1.24.9"
     }
   }
 }

--- a/cluster/terraform_aks_cluster/main.tf
+++ b/cluster/terraform_aks_cluster/main.tf
@@ -8,17 +8,19 @@ resource "azurerm_kubernetes_cluster" "main" {
   resource_group_name = data.azurerm_resource_group.cluster.name
   node_resource_group = local.node_resource_group_name
   dns_prefix          = local.dns_prefix
+  kubernetes_version  = var.kubernetes_version
 
   oms_agent {
     log_analytics_workspace_id = azurerm_log_analytics_workspace.aks_system_logs.id
   }
 
   default_node_pool {
-    name           = "default"
-    node_count     = var.default_node_pool.node_count
-    vm_size        = "Standard_D2_v2"
-    vnet_subnet_id = azurerm_subnet.aks-subnet.id
-    zones          = local.uk_south_availability_zones
+    name                 = "default"
+    node_count           = var.default_node_pool.node_count
+    vm_size              = "Standard_D2_v2"
+    vnet_subnet_id       = azurerm_subnet.aks-subnet.id
+    zones                = local.uk_south_availability_zones
+    orchestrator_version = var.default_node_pool.orchestrator_version
   }
 
   identity {
@@ -38,6 +40,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "node_pools" {
   enable_auto_scaling   = true
   min_count             = each.value.min_count
   max_count             = each.value.max_count
+  orchestrator_version  = each.value.orchestrator_version
   vnet_subnet_id        = azurerm_subnet.aks-subnet.id
   zones                 = local.uk_south_availability_zones
   node_labels           = try(each.value.node_labels, {})

--- a/cluster/terraform_aks_cluster/variables.tf
+++ b/cluster/terraform_aks_cluster/variables.tf
@@ -15,6 +15,7 @@ variable "config" { type = string }
 variable "cip_tenant" { type = bool }
 variable "default_node_pool" { type = map(any) }
 variable "node_pools" { type = any }
+variable "kubernetes_version" { type = string }
 
 locals {
   azure_credentials = try(jsondecode(var.azure_sp_credentials_json), null)

--- a/documentation/aks-upgrade.md
+++ b/documentation/aks-upgrade.md
@@ -1,0 +1,99 @@
+# AKS upgrade
+
+AKS is continously updated and follows the Kubernetes release cycle. We must follow it as well to:
+
+- Run a supported version
+- Receive security updates
+- Use new features
+- Not add technical debt due to version incompatibilities
+
+## Questions
+
+### Which Kubernetes versions are supported by Microsoft?
+
+*Kubernetes support policy*
+Kubernetes follow a estimated three month update release cycle. Kubernetes will support each minor version for one year after release.
+
+*Microsoft AKS version support*
+Microsoft mirrors the Kubernetes support policy. Microsoft support the latest GA version alongside two previously released GA versions.
+
+Microsoft follow the Azure Safe Deployment Practices [(SDP)](https://learn.microsoft.com/en-us/devops/operate/safe-deployment-practices). A release can take up to two weeks to roll out into all regions.
+
+### How do I track the release cycle?
+
+The [AKS Release Tracker](https://releases.aks.azure.com/webpage/index.html) should be monitored, this is useful to:
+- View release notes
+- Track specific features / fixes
+- Data is updated real time
+- View SDP rollout progress
+
+The [Azure Update page](https://azure.microsoft.com/en-gb/updates/?category=containers) is another available feed.
+
+### And Node OS Upgrades?
+Microsoft release weekly updates to the Linux OS image. By default, a OS image update is carried each time the node pool is updated.
+
+Currently, terraform will only update the node OS image when the AKS version is upgraded (See [GitHub issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/20171)).
+We should consider configuring node auto upgrade in the future.
+
+## Version information
+
+### Terraform
+Each tfvars.json environment file contains:
+
+- kubernetes_version
+- default_node_pool orchestrator version
+- each node pool orchestrator version
+
+### Show cluster kubernetes version
+
+```
+az aks show --resource-group <ResourceGroup> --name <ClusterName> --query kubernetesVersion -o json
+```
+
+### Show orchestrator version on node pools
+
+```
+az aks nodepool list --resource-group <ResourceGroup> --cluster-name <ClusterName> --query "[].{Name:name,k8version:orchestratorVersion}" --output table
+```
+
+### Show available versions
+To show available versions:
+
+```
+az aks get-versions --location uksouth --output table
+```
+
+To check available version for deployed cluster:
+
+```
+az aks get-upgrades --resource-group <ResourceGroup> --name <ClusterName> --output table
+```
+
+### Node image
+
+Current image:
+```
+az aks nodepool show --resource-group <ResourceGroup> --cluster-name <ClusterName> --name <NodePoolName> --query nodeImageVersion
+```
+
+Available image:
+```
+az aks nodepool get-upgrades --resource-group <ResourceGroup> --cluster-name <ClusterName> --nodepool-name <NodePoolName>
+```
+
+## Upgrade process
+
+1. Determine which is the next available version (see above)
+1. Test the whole process in a dev cluster:
+    - Deploy Apply to the cluster using `dev_platform_review_aks`
+    - Continuously monitor it during the upgrade and check for downtime. Example:
+
+        ```
+        while true; do date; curl -is https://apply-review-1234.cluster4.development.teacherservices.cloud/check | grep HTTP ; sleep 1 ; done
+        ```
+    - Change kubernetes version, plan and apply
+    - Change default node pool orchestrator version, plan and apply
+    - Change application node pool orchestrator version, plan and apply
+1. Follow the same manual process to upgrade the platform_test cluster, raise PR, wait 24h
+1. Follow the same manual process to upgrade the test cluster, raise PR, wait 24h
+1. Follow the same manual process to upgrade the production cluster, raise PR


### PR DESCRIPTION
**Context**

To be able to carry out a cluster and node upgrade using Terraform. 

**Changes proposed**

- Add parameter kubernetes_version - This sets the cluster version
- Add parameter orchestrator_version - This sets the version for the default node pool and the application node pools. 
- Provide guidance about the upgrade process, including the auto-upgrade feature

**Documentation describing AKS upgrade considerations**

[AKS Upgrade Considerations](https://hackmd.cloudapps.digital/Aal84OmxQR67u7UaNL4Faw)

**Guidance for review**
cluster2 was deployed into the development environment. The following text describe the upgrade process.

**Cluster and Node Upgrade Process**

To deploy cluster2 into the development subscription, ran below command:

```make development terraform-apply ENVIRONMENT=cluster2```

Once complete, the following result should be returned:
![image](https://user-images.githubusercontent.com/123001665/222085332-c08a2a6f-afd5-4560-9606-b39615578963.png)

Once deployment was completed, I ran the below command to show the current version numbers

```az aks show --name s189d01-tsc-cluster2-aks --resource-group s189d01-tsc-dv-rg --query kubernetesVersion -o json```

![image](https://user-images.githubusercontent.com/123001665/222085502-b21126c7-0fd8-4d9e-b912-8e6e22d93268.png)

Run below command to show orchestrator version:

```az aks nodepool list --resource-group s189d01-tsc-dv-rg --cluster-name s189d01-tsc-cluster2-aks --query "[].{Name:name,k8version:orchestratorVersion}" --output table```

![image](https://user-images.githubusercontent.com/123001665/222085655-b9f03564-6d35-4bb1-9978-343168924b7c.png)

To show available versions:

```az aks get-versions --location uksouth --output table```

![image](https://user-images.githubusercontent.com/123001665/222085775-068205e2-2f6d-46ca-be14-c9952b48121a.png)

To check available version for deployed cluster

```az aks get-upgrades --resource-group s189d01-tsc-dv-rg --name s189d01-tsc-cluster2-aks --output table```

![image](https://user-images.githubusercontent.com/123001665/222086039-06596aad-a464-41bd-9585-ce1043234101.png)

We are going to upgrade the default node pool to 1.25.4 - We are then going to upgrade the applications node pool also to 1.25.4. We will do this using the Terraform code and by setting the below values:

![image](https://user-images.githubusercontent.com/123001665/222086092-e732510f-8b26-4732-ba19-820414b26c29.png)

We re-run the Terraform plan:

```make development terraform-plan ENVIRONMENT=cluster2 ```

![image](https://user-images.githubusercontent.com/123001665/222086211-dcabfb8a-ae2c-4dae-82d5-d12aa55bd14b.png)

A in-place upgrade cluster upgrade will be carried out after running the apply:

```make development terraform-apply ENVIRONMENT=cluster2 ```

![image](https://user-images.githubusercontent.com/123001665/222086357-64311848-4efd-457b-a51f-497692395e19.png)

The portal shows the cluster has been upgraded:

![image](https://user-images.githubusercontent.com/123001665/222086497-ab6c70dd-c5d4-431c-94fe-6e75d7552fcd.png)

Alternatively run this cli command:

```az aks show --name s189d01-tsc-cluster2-aks --resource-group s189d01-tsc-dv-rg --query kubernetesVersion -o json```

![image](https://user-images.githubusercontent.com/123001665/222086604-f54046b1-6e02-4a75-ab73-90cb0a20ce05.png)

Now we are going to upgrade both application and default node pools to version 1.25.4. We amend the development. tfvars.json file:

![image](https://user-images.githubusercontent.com/123001665/222086683-36025752-42aa-4f03-bf5b-4892258c9e28.png)


Re-run the plan

make development terraform-plan ENVIRONMENT=cluster2 

![image](https://user-images.githubusercontent.com/123001665/222086795-f80a3d47-3518-4b26-bd3b-15b690fdd19f.png)

![image](https://user-images.githubusercontent.com/123001665/222086823-14641ac6-2f5b-4517-a6ae-a45a2da88291.png)

If your happy with the plan, rerun the apply:

make development terraform-apply ENVIRONMENT=cluster2 

![image](https://user-images.githubusercontent.com/123001665/222086953-a4d9e63c-8173-4c2f-8ed9-6c319628835b.png)

![image](https://user-images.githubusercontent.com/123001665/222086990-3091260e-9d51-4926-8198-a6b8f1cbb5c3.png)

We would not recommend upgrading default and application node pools simultaneously outside the development environment. In development only one node is available, so short application downtime would occur. If the node count were to increase, this downtime would be avoided.

This completes the process to upgrade both cluster and node pools.
