### PR TITLE
[81] Increase ingress-nginx replicas to 20

### DIFF
--- a/cluster/terraform/kubernetes-config/ingress_controller.tf
+++ b/cluster/terraform/kubernetes-config/ingress_controller.tf
@@ -19,4 +19,9 @@ resource "helm_release" "ingress-nginx" {
     name  = "controller.config.proxy-buffer-size"
     value = "8k"
   }
+
+  set {
+    name  = "controller.replicaCount"
+    value = 20
+  }
 }

--- a/cluster/terraform/kubernetes-config/ingress_controller.tf
+++ b/cluster/terraform/kubernetes-config/ingress_controller.tf
@@ -4,24 +4,30 @@ resource "helm_release" "ingress-nginx" {
   chart      = "ingress-nginx"
   version    = "4.4.0"
 
+  # The first part of the name with simple dots is the keys path in the values.yml file e.g. controller.service.annotations
+  # The last part is the final key e.g. service\\.beta\\.kubernetes\\.io/azure-load-balancer-health-probe-request-path
+  # It may have double escaped dots if the key contains dots e.g. \\.
+  # The corresponding value is in the "value" argument
+  # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   set {
     name  = "controller.service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-health-probe-request-path"
     value = "/healthz"
     type  = "string"
   }
-
   set {
     name  = "controller.extraArgs.default-ssl-certificate"
     value = "default/cert-secret"
   }
-
   set {
     name  = "controller.config.proxy-buffer-size"
     value = "8k"
   }
-
   set {
     name  = "controller.replicaCount"
     value = 20
+  }
+  set {
+    name  = "controller.nodeSelector.kubernetes\\.azure\\.com/agentpool"
+    value = "applications"
   }
 }


### PR DESCRIPTION
## What
Outcome of the load tests: https://trello.com/c/ZQlq0Rdd
Apply with 8 replicas requires 2 ingress-nginx replicas using 100m CPU. 20 should be enough for a while.

## How to review
Check replicas on cluster 3:
```
kubectl get pods
```