### PR TITLE
Add statuscake monitor for persistent clusters

### DIFF
--- a/cluster/terraform/config/platform-test.tfvars.json
+++ b/cluster/terraform/config/platform-test.tfvars.json
@@ -15,5 +15,15 @@
         "min_count": 2,
         "max_count": 6
       }
+    },
+    "statuscake_alerts": {
+      "tscluster-platform-test": {
+        "website_name": "Teacher-Services-AKS-Cluster-PLATFORM-TEST",
+        "website_url": "https://status.platform-test.teacherservices.cloud/healthz",
+        "check_rate": 60,
+        "contact_group": [
+          282453
+        ]
+      }
     }
   }

--- a/cluster/terraform/config/production.tfvars.json
+++ b/cluster/terraform/config/production.tfvars.json
@@ -10,5 +10,15 @@
       "min_count": 3,
       "max_count": 10
     }
+  },
+  "statuscake_alerts": {
+    "tscluster-production": {
+      "website_name": "Teacher-Services-AKS-Cluster-PRODUCTION",
+      "website_url": "https://status.teacherservices.cloud/healthz",
+      "check_rate": 60,
+      "contact_group": [
+        282453
+      ]
+    }
   }
 }

--- a/cluster/terraform/config/test.tfvars.json
+++ b/cluster/terraform/config/test.tfvars.json
@@ -14,5 +14,15 @@
       "min_count": 2,
       "max_count": 10
     }
+  },
+  "statuscake_alerts": {
+    "tscluster-test": {
+      "website_name": "Teacher-Services-AKS-Cluster-TEST",
+      "website_url": "https://status.test.teacherservices.cloud/healthz",
+      "check_rate": 60,
+      "contact_group": [
+        282453
+      ]
+    }
   }
 }

--- a/cluster/terraform/main.tf
+++ b/cluster/terraform/main.tf
@@ -30,3 +30,18 @@ module "kubernetes-config" {
   ingress_cert_name   = var.ingress_cert_name
   namespaces          = var.namespaces
 }
+
+module "statuscake" {
+  source = "./statuscake"
+  alerts = var.statuscake_alerts
+}
+
+data "azurerm_key_vault" "key_vault" {
+  name                = var.cluster_kv
+  resource_group_name = var.resource_group_name
+}
+
+data "azurerm_key_vault_secret" "statuscake_secret" {
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  name         = "STATUSCAKE-API-TOKEN"
+}

--- a/cluster/terraform/statuscake/main.tf
+++ b/cluster/terraform/statuscake/main.tf
@@ -1,0 +1,69 @@
+terraform {
+  required_providers {
+    statuscake = {
+      source  = "StatusCakeDev/statuscake"
+      version = "2.0.4"
+    }
+  }
+}
+
+resource "statuscake_uptime_check" "alert" {
+  for_each = var.alerts
+
+  name           = each.value.website_name
+  check_interval = each.value.check_rate
+  confirmation   = 2
+  trigger_rate   = 0
+  regions        = [ "london", "dublin" ]
+  contact_groups = each.value.contact_group
+
+  http_check {
+    follow_redirects = true
+    timeout          = 40
+    request_method   = "HTTP"
+    status_codes     = [
+      "204",
+      "205",
+      "206",
+      "303",
+      "400",
+      "401",
+      "403",
+      "404",
+      "405",
+      "406",
+      "408",
+      "410",
+      "413",
+      "444",
+      "429",
+      "494",
+      "495",
+      "496",
+      "499",
+      "500",
+      "501",
+      "502",
+      "503",
+      "504",
+      "505",
+      "506",
+      "507",
+      "508",
+      "509",
+      "510",
+      "511",
+      "521",
+      "522",
+      "523",
+      "524",
+      "520",
+      "598",
+      "599"
+    ]
+  }
+
+  monitored_resource {
+    address = each.value.website_url
+  }
+}

--- a/cluster/terraform/statuscake/variables.tf
+++ b/cluster/terraform/statuscake/variables.tf
@@ -1,0 +1,1 @@
+variable "alerts" { type = map(any) }

--- a/cluster/terraform/terraform.tf
+++ b/cluster/terraform/terraform.tf
@@ -13,6 +13,10 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "2.18.1"
     }
+    statuscake = {
+      source  = "StatusCakeDev/statuscake"
+      version = "2.0.4"
+    }
   }
   backend "azurerm" {
     container_name = "tsc-tfstate"
@@ -43,4 +47,8 @@ provider "helm" {
     client_certificate     = base64decode(data.azurerm_kubernetes_cluster.main.kube_config[0].client_certificate)
     cluster_ca_certificate = base64decode(data.azurerm_kubernetes_cluster.main.kube_config[0].cluster_ca_certificate)
   }
+}
+
+provider "statuscake" {
+  api_token = local.api_token
 }

--- a/cluster/terraform/variables.tf
+++ b/cluster/terraform/variables.tf
@@ -31,6 +31,13 @@ variable "namespaces" { type = list(string) }
 variable "default_node_pool" { type = map(any) }
 variable "node_pools" { type = map(any) }
 
+# StatusCake variables
+variable "statuscake_alerts" {
+  type    = map(any)
+  default = {}
+}
+
 locals {
   azure_credentials = try(jsondecode(var.azure_sp_credentials_json), null)
+  api_token         = data.azurerm_key_vault_secret.statuscake_secret.value
 }


### PR DESCRIPTION
## What
Add statuscake monitors for persistent clusters,
i.e. test, platform-test and production
Monitors the /healthz endpoint every 60 seconds 

Also added contact group to statuscake,
and added required KV secrets

## How to review
make env terraform-plan
also tested using dev cluster5. see Teacher-Services-AKS-Cluster-DEV5 in statuscake