### PR TITLE
[207] Capture AKS system logs into a log analytics workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,6 @@ Reference:
 - [Terraform: don’t use kubernetes provider with your cluster resource!](https://itnext.io/terraform-dont-use-kubernetes-provider-with-your-cluster-resource-d8ec5319d14a)
 - [Stacking with managed Kubernetes cluster resources](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#stacking-with-managed-kubernetes-cluster-resources)
 - [terraform-provider-kubernetes](https://github.com/hashicorp/terraform-provider-kubernetes/tree/main/_examples/aks#replacing-the-aks-cluster-and-re-creating-the-kubernetes--helm-resources)
+
+## Links
+- [Retrieving Log Analytics Data with KQL for AKS Clusters](documentation/aks-logs.md)

--- a/cluster/terraform/.terraform.lock.hcl
+++ b/cluster/terraform/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "3.44.1"
   hashes = [
     "h1:7zeUPl2nDhKnWHpAeKy+7Cued79RDgwacN/qpTIim64=",
+    "h1:dq7s/3sZrI4oLWL/NUlOcOD3HGkzimRmEvFiWX+ENRw=",
     "zh:0a1761b5aeec47d5019114976de5eb9832dea1d57d632ca6fa464b99b782d1c1",
     "zh:0e9c96fa7ed6d55a3f3a646ff346298c8b7728331bb3a74875f78ecb7d245c16",
     "zh:1aa953a692c7b5b10219343f0238f4624ac988e247721b6ec6b1bed2b81f7ceb",
@@ -26,6 +27,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   constraints = "2.9.0"
   hashes = [
     "h1:3M1gPJ2W3qtYr6do1HkH5l03kSEHIYMQ97W2tP59dYY=",
+    "h1:fEDID5J/9ret/sLpOSNAu98F/ZBEZhOmL0Leut7m5JU=",
     "zh:1471cb45908b426104687c962007b2980cfde294fa3530fabc4798ce9fb6c20c",
     "zh:1572e9cec20591ec08ece797b3630802be816a5adde36ca91a93359f2430b130",
     "zh:1b10ae03cf5ab1ae21ffaac2251de99797294ae4242b156b3b0beebbdbcb7e0f",
@@ -46,6 +48,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   constraints = "2.18.1"
   hashes = [
     "h1:vBRsQjT8QeFe8C9yJ1PR43wzX4hM5UssxlHkPPo34gU=",
+    "h1:y4VED+vsulAqE7YbQC7x1XXrzvi/dEIjupttSyzSA/M=",
     "zh:09d69d244f5e688d9b1582112aa5d151c5336278e43d39c88ae920c26536b753",
     "zh:0df4c988056f7d84d9161c6c955ad7346364c261d100ef510a6cc7fa4a235197",
     "zh:2d3d0cb2931b6153a7971ce8c6fae92722b1116e16f42abbaef115dba895c8d8",

--- a/cluster/terraform/aks-cluster/analytics.tf
+++ b/cluster/terraform/aks-cluster/analytics.tf
@@ -1,0 +1,66 @@
+# Create Log Analytics workspace
+resource "azurerm_log_analytics_workspace" "aks_system_logs" {
+  name                = "${var.resource_prefix}-tsc-${var.environment}-log"
+  location            = data.azurerm_resource_group.cluster.location
+  resource_group_name = data.azurerm_resource_group.cluster.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+resource "azurerm_monitor_diagnostic_setting" "aks_logs" {
+  name                       = "aks-logs"
+  target_resource_id         = azurerm_kubernetes_cluster.main.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.aks_system_logs.id
+
+  # in order to find the categories goto the json view on the diagnostics settings pane
+  # its currently set to this as default and can be expanded upon
+  enabled_log {
+    category = "kube-apiserver"
+
+    retention_policy {
+      enabled = true
+      days    = 10
+    }
+  }
+
+  enabled_log {
+    category = "kube-audit-admin"
+
+    retention_policy {
+      enabled = true
+      days    = 10
+    }
+  }
+  enabled_log {
+    category = "kube-controller-manager"
+
+    retention_policy {
+      enabled = true
+      days    = 10
+    }
+  }
+  enabled_log {
+    category = "kube-scheduler"
+
+    retention_policy {
+      enabled = true
+      days    = 10
+    }
+  }
+  enabled_log {
+    category = "cluster-autoscaler"
+
+    retention_policy {
+      enabled = true
+      days    = 10
+    }
+  }
+  enabled_log {
+    category = "cloud-controller-manager"
+
+    retention_policy {
+      enabled = true
+      days    = 10
+    }
+  }
+}

--- a/cluster/terraform/aks-cluster/main.tf
+++ b/cluster/terraform/aks-cluster/main.tf
@@ -9,6 +9,10 @@ resource "azurerm_kubernetes_cluster" "main" {
   node_resource_group = local.node_resource_group_name
   dns_prefix          = local.dns_prefix
 
+  oms_agent {
+    log_analytics_workspace_id = azurerm_log_analytics_workspace.aks_system_logs.id
+  }
+
   default_node_pool {
     name           = "default"
     node_count     = var.default_node_pool.node_count
@@ -22,6 +26,7 @@ resource "azurerm_kubernetes_cluster" "main" {
   }
 
   lifecycle { ignore_changes = [tags] }
+
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "node_pools" {

--- a/documentation/aks-logs.md
+++ b/documentation/aks-logs.md
@@ -1,0 +1,48 @@
+# Retrieving Log Analytics Data with KQL for AKS Clusters
+
+Kusto Query Language (KQL) is a query language that you can use to retrieve data from Log Analytics workspaces for Azure Kubernetes Service (AKS) clusters. In this guide, we will explain how to write KQL queries to retrieve Log Analytics data and analyze it for your AKS cluster.
+
+N.B. please allow around 15 mins for the logs to be generated and ingested into the log analytics workspace
+
+## Writing KQL Queries
+
+To write a KQL query to retrieve AKS Log Analytics data, follow these steps:
+
+1. Open the Azure portal and navigate to your resource group where the cluster is deployed.
+
+2. Navigate to the AKS instance, then “Logs” under the “Monitoring” section of the blade on the left of the AKS cluster on the portal. Click on the Log Analytics Workspace link.
+
+3. In the query editor, you can start typing your KQL query. For example, you might want to retrieve all control plane logs from the last 24 hours:
+
+    ```
+    AzureDiagnostics
+    | where Category == "kube-apiserver"
+    | where TimeGenerated >= ago(24h)
+    ```
+
+4. Press the "Run" button to execute the query.
+
+5. The results of the query will be displayed in the "Results" tab. You can further refine and analyze the data using the tools in the query editor.
+
+## Query Examples
+
+Here are some examples of KQL queries that you can use to retrieve AKS Log Analytics data:
+
+- Retrieve all container inventory with the state terminated:
+
+    ```
+    ContainerInventory
+    | where ContainerState == "Terminated"
+    | project Computer, Name, Image, ImageTag, ContainerState, CreatedTime, StartedTime, FinishedTime
+    | render table
+
+    ```
+
+- Retrieve all admin audit logs:
+
+    ```
+    AzureDiagnostics
+    | where Category == "kube-audit-admin"
+    ```
+
+These are just a few examples of the many queries that you can write using KQL to retrieve AKS Log Analytics data.


### PR DESCRIPTION
## What
We need to keep system logs to troubleshoot issues and incidents.

Log analytics is default on AKS. Diagnostic logs must be enabled and maybe container insights. We should implement it via terraform for platform-test, test and production clusters.

This is an initial implementation and may be refined later. The cost should be kept minimal.

## How to review
Check for the changes in the diagnostics settings are set in cluster 1
for example ..
Kubernetes API Server should have a check mark enabled

In the Logs please run this kql query
```
AzureDiagnostics
| where Category == "kube-apiserver"
```
