### PR TITLE
Increase Test cluster app nodepool max size to 20

### DIFF
--- a/cluster/terraform_aks_cluster/config/test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/test.tfvars.json
@@ -6,7 +6,7 @@
   "node_pools": {
     "applications": {
       "min_count": 2,
-      "max_count": 10
+      "max_count": 20
     }
   }
 }


### PR DESCRIPTION
## What
Increase Test cluster applications nodepool maximum size from 10 to 20
Due to currently hitting the maximum of 10 and unable to deploy new apps or update existing

## How to review
make test terraform-plan
