### PR TITLE
Change max node count to 20

### DIFF
--- a/cluster/terraform_aks_cluster/config/production.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/production.tfvars.json
@@ -6,7 +6,7 @@
   "node_pools": {
     "applications": {
       "min_count": 3,
-      "max_count": 10
+      "max_count": 20
     }
   }
 }


### PR DESCRIPTION
**Context**
The apply service was failing to deploy due to the node count set to 10. 
Apply service needed to resources than were available in the cluster.

**Changes proposed**
- Increase the node count to 20

