### PR TITLE
Code to support node labels and node VM sizes

### DIFF
--- a/cluster/terraform_aks_cluster/.terraform.lock.hcl
+++ b/cluster/terraform_aks_cluster/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "3.46.0"
   hashes = [
     "h1:4bgmpjuKWdCCzk4CK7PJJQ/B1iCNCFom0sEaJ+4szVk=",
+    "h1:YQh2ZPZULfNb+m9hAiEIsWdi8Wx04mcmaa2ftdWsUKo=",
     "zh:02327ad31c998d9d55bafd280a4b1bd3702b496e49f53fad30823712cc85368a",
     "zh:05882df6b5b59d23e2aa0c454caea84fcc35e435eb925e18293415260b4850c8",
     "zh:0c0d6309abcfa24f0775df9bff81cb8f63029fead66956316d7cfa837c231873",

--- a/cluster/terraform_aks_cluster/config/development.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/development.tfvars.json
@@ -6,7 +6,17 @@
   "node_pools": {
     "applications": {
       "min_count": 1,
-      "max_count": 2
+      "max_count": 2,
+      "node_labels": {
+        "teacherservices.cloud/node_pool": "applications"
+      }
+    },
+    "apps1": {
+      "min_count": 1,
+      "max_count": 2,
+      "node_labels": {
+        "teacherservices.cloud/node_pool": "applications"
+      }
     }
   }
 }

--- a/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
@@ -6,7 +6,17 @@
   "node_pools": {
     "applications": {
       "min_count": 2,
-      "max_count": 6
+      "max_count": 6,
+      "node_labels": {
+        "teacherservices.cloud/node_pool": "applications"
+      }
+    },
+    "apps1": {
+      "min_count": 2,
+      "max_count": 6,
+      "node_labels": {
+        "teacherservices.cloud/node_pool": "applications"
+      }
     }
   }
 }

--- a/cluster/terraform_aks_cluster/config/production.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/production.tfvars.json
@@ -6,7 +6,18 @@
   "node_pools": {
     "applications": {
       "min_count": 3,
-      "max_count": 20
+      "max_count": 10,
+      "node_labels": {
+        "teacherservices.cloud/node_pool": "applications"
+      }
+    },
+    "apps1": {
+      "min_count": 3,
+      "max_count": 20,
+      "vm_size": "Standard_E4ads_v5",
+      "node_labels": {
+        "teacherservices.cloud/node_pool": "applications"
+      }
     }
   }
 }

--- a/cluster/terraform_aks_cluster/config/test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/test.tfvars.json
@@ -6,7 +6,18 @@
   "node_pools": {
     "applications": {
       "min_count": 2,
-      "max_count": 20
+      "max_count": 20,
+      "node_labels": {
+        "teacherservices.cloud/node_pool": "applications"
+      }
+    },
+    "apps1": {
+      "min_count": 2,
+      "max_count": 20,
+      "vm_size": "Standard_E4ads_v5",
+      "node_labels": {
+        "teacherservices.cloud/node_pool": "applications"
+      }
     }
   }
 }

--- a/cluster/terraform_aks_cluster/main.tf
+++ b/cluster/terraform_aks_cluster/main.tf
@@ -34,10 +34,11 @@ resource "azurerm_kubernetes_cluster_node_pool" "node_pools" {
 
   name                  = each.key
   kubernetes_cluster_id = azurerm_kubernetes_cluster.main.id
-  vm_size               = "Standard_D2_v2"
+  vm_size               = try(each.value.vm_size, "Standard_D2_v2")
   enable_auto_scaling   = true
   min_count             = each.value.min_count
   max_count             = each.value.max_count
   vnet_subnet_id        = azurerm_subnet.aks-subnet.id
   zones                 = local.uk_south_availability_zones
+  node_labels           = try(each.value.node_labels, {})
 }

--- a/cluster/terraform_aks_cluster/variables.tf
+++ b/cluster/terraform_aks_cluster/variables.tf
@@ -14,7 +14,7 @@ variable "config" { type = string }
 # Set in config json file
 variable "cip_tenant" { type = bool }
 variable "default_node_pool" { type = map(any) }
-variable "node_pools" { type = map(any) }
+variable "node_pools" { type = any }
 
 locals {
   azure_credentials = try(jsondecode(var.azure_sp_credentials_json), null)

--- a/cluster/terraform_kubernetes/.terraform.lock.hcl
+++ b/cluster/terraform_kubernetes/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "3.46.0"
   hashes = [
     "h1:4bgmpjuKWdCCzk4CK7PJJQ/B1iCNCFom0sEaJ+4szVk=",
+    "h1:YQh2ZPZULfNb+m9hAiEIsWdi8Wx04mcmaa2ftdWsUKo=",
     "zh:02327ad31c998d9d55bafd280a4b1bd3702b496e49f53fad30823712cc85368a",
     "zh:05882df6b5b59d23e2aa0c454caea84fcc35e435eb925e18293415260b4850c8",
     "zh:0c0d6309abcfa24f0775df9bff81cb8f63029fead66956316d7cfa837c231873",
@@ -67,6 +68,7 @@ provider "registry.terraform.io/statuscakedev/statuscake" {
   version     = "2.0.4"
   constraints = "2.0.4"
   hashes = [
+    "h1:ZWhLMoREWISsr9NkKNGdqeCWV0yr9cU+DOWSa5l8ZeA=",
     "h1:y2dthcfU+b/p0q6ZCa2u61cp1QnmeX1k63cylKEQ+KY=",
     "zh:0a0962aff7c3112c8b32182e3e80974f1d334a73570450c8a834cde905b804f6",
     "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",

--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -35,7 +35,7 @@ resource "helm_release" "ingress-nginx" {
     value = 20
   }
   set {
-    name  = "controller.nodeSelector.kubernetes\\.azure\\.com/agentpool"
+    name  = "controller.nodeSelector.teacherservices\\.cloud/node_pool"
     value = "applications"
   }
 


### PR DESCRIPTION
## Context
We need a way to change the VM size of a new cluster.
We also need a process to move existing workloads from one cluster to another if we wanted to move to a node pool with bigger VM's.

## Changes proposed in this pull request

Add code to support changing the VM size of a node pool from the `tfvars.json` file.
Add code to support adding labels to a node pool from the `tfvars.json` file.

## Implementing these changes

1. Deploy the cluster to add the label to the existing node and deploy a new node with the new label
2. Deploy any applications running on the existing cluster ensuring their node selector uses the new label
3. Migrate the workloads to the new node
a) Disable autoscaling on the existing node
b) Cordon the existing nodes in the existing node pool
c) Drain the existing node - this should drain and move the existing workloads to the new node pool
d) Update the tfvar.json file for the environment, remove the `applications` node pool and deploy to the cluster. This will delete the old node so ensure no workloads are running on it first
8. Depending on the nodes pod disruption budget there may be a short period of downtime while the applications pods are evicted and scheduled on the new node