### PR TITLE
Remove old node pools

### DIFF
--- a/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
@@ -4,13 +4,6 @@
     "node_count": 2
   },
   "node_pools": {
-    "applications": {
-      "min_count": 2,
-      "max_count": 6,
-      "node_labels": {
-        "teacherservices.cloud/node_pool": "applications"
-      }
-    },
     "apps1": {
       "min_count": 2,
       "max_count": 6,

--- a/cluster/terraform_aks_cluster/config/production.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/production.tfvars.json
@@ -4,13 +4,6 @@
     "node_count": 3
   },
   "node_pools": {
-    "applications": {
-      "min_count": 3,
-      "max_count": 10,
-      "node_labels": {
-        "teacherservices.cloud/node_pool": "applications"
-      }
-    },
     "apps1": {
       "min_count": 3,
       "max_count": 20,

--- a/cluster/terraform_aks_cluster/config/test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/test.tfvars.json
@@ -4,13 +4,6 @@
     "node_count": 2
   },
   "node_pools": {
-    "applications": {
-      "min_count": 2,
-      "max_count": 20,
-      "node_labels": {
-        "teacherservices.cloud/node_pool": "applications"
-      }
-    },
     "apps1": {
       "min_count": 2,
       "max_count": 20,


### PR DESCRIPTION
## Context
We have changed the label used by the node selector so that it isn't specific to the node pool (e.g. agentpool), but can be a label which is added to multiple node pools (e.g. a custom label).

## Changes proposed in this pull request
Remove the nodes which are no longer required

## Prior to merging this pull request
- [x] Confirm workloads deployed on the node being delete can be provisioned on the new node by checking the node selector for deployed applications has been updated to include `"teacherservices.cloud/node_pool" = "applications"`
- [x] Go through the process of cordoning, and draining the node which is being removed so that workloads are provisioned on the newer node pool.