### PR TITLE
check-cluster-exists make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,11 @@ terraform-kubernetes-apply: terraform-kubernetes-init
 terraform-kubernetes-destroy: terraform-kubernetes-init
 	terraform -chdir=cluster/terraform_kubernetes destroy -var-file config/${CONFIG}.tfvars.json ${TF_VARS_KUBERNETES} ${AUTO_APPROVE}
 
+check-cluster-exists:
+	terraform -chdir=cluster/terraform_aks_cluster output -json | jq -e '.cluster_id' > /dev/null
+
 terraform-init: terraform-aks-cluster-init terraform-kubernetes-init
-terraform-plan: terraform-init terraform-aks-cluster-plan terraform-kubernetes-plan
+terraform-plan: terraform-init terraform-aks-cluster-plan check-cluster-exists terraform-kubernetes-plan
 terraform-apply: terraform-init terraform-aks-cluster-apply terraform-kubernetes-apply
 terraform-destroy: terraform-init terraform-kubernetes-destroy terraform-aks-cluster-destroy
 

--- a/cluster/terraform_aks_cluster/output.tf
+++ b/cluster/terraform_aks_cluster/output.tf
@@ -1,3 +1,7 @@
 output "cluster_name" {
   value = local.cluster_name
 }
+
+output "cluster_id" {
+  value = azurerm_kubernetes_cluster.main.id
+}


### PR DESCRIPTION
## What
Fix an issue when running terraform plan when there is no cluster created. The terraform_kubernetes terraform apply requires the cluster to exist or fails.
This now checks the cluster exists by checking the output from terraform_aks_cluster before running terraform_kubernetes.

## How to review
Run with no cluster. You should get `make: *** [check-cluster-exists] Error 1` but no terraform plan error.