### PR TITLE
Enable Azure AD auth with Azure RBAC

### DIFF
--- a/cluster/terraform_aks_cluster/.terraform.lock.hcl
+++ b/cluster/terraform_aks_cluster/.terraform.lock.hcl
@@ -7,6 +7,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   hashes = [
     "h1:4bgmpjuKWdCCzk4CK7PJJQ/B1iCNCFom0sEaJ+4szVk=",
     "h1:YQh2ZPZULfNb+m9hAiEIsWdi8Wx04mcmaa2ftdWsUKo=",
+    "h1:hCCSjeSMrt6/hS6byqecfDVHBgiwD3BCUy1YtJJl4So=",
     "zh:02327ad31c998d9d55bafd280a4b1bd3702b496e49f53fad30823712cc85368a",
     "zh:05882df6b5b59d23e2aa0c454caea84fcc35e435eb925e18293415260b4850c8",
     "zh:0c0d6309abcfa24f0775df9bff81cb8f63029fead66956316d7cfa837c231873",

--- a/cluster/terraform_aks_cluster/config/development.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/development.tfvars.json
@@ -1,5 +1,8 @@
 {
   "cip_tenant": true,
+  "azure_rbac_enabled": true,
+  "role_based_access_control_enabled": true,
+  "local_account_disabled": true,
   "default_node_pool": {
     "node_count": 1
   },

--- a/cluster/terraform_aks_cluster/main.tf
+++ b/cluster/terraform_aks_cluster/main.tf
@@ -25,6 +25,18 @@ resource "azurerm_kubernetes_cluster" "main" {
     type = "SystemAssigned"
   }
 
+
+  role_based_access_control_enabled = var.role_based_access_control_enabled
+
+  dynamic "azure_active_directory_role_based_access_control" {
+    for_each = var.role_based_access_control_enabled ? [1] : []
+    content {
+       azure_rbac_enabled = var.azure_rbac_enabled
+       managed            = var.managed
+    }
+  }
+
+  local_account_disabled = var.local_account_disabled
   lifecycle { ignore_changes = [tags] }
 
 }

--- a/cluster/terraform_aks_cluster/variables.tf
+++ b/cluster/terraform_aks_cluster/variables.tf
@@ -15,6 +15,26 @@ variable "config" { type = string }
 variable "cip_tenant" { type = bool }
 variable "default_node_pool" { type = map(any) }
 variable "node_pools" { type = any }
+variable "azure_rbac_enabled" { 
+   description = "Variable to determine if Azure AD RBAC authentication is enabled"
+   type = bool
+   default = false
+}
+variable "managed" {
+   description = "Variable to determine if Azure Active Directory integration is managed"
+   type = bool
+   default = true
+}
+variable "role_based_access_control_enabled" {
+   description = "Variable to determine if role based access control is enabled"
+   type = bool
+   default = false
+}
+variable "local_account_disabled" {
+   description = "Optional variable to determine if local accounts are enabled"
+   type = bool
+   default = false
+}
 
 locals {
   azure_credentials = try(jsondecode(var.azure_sp_credentials_json), null)

--- a/cluster/terraform_kubernetes/.terraform.lock.hcl
+++ b/cluster/terraform_kubernetes/.terraform.lock.hcl
@@ -7,6 +7,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   hashes = [
     "h1:4bgmpjuKWdCCzk4CK7PJJQ/B1iCNCFom0sEaJ+4szVk=",
     "h1:YQh2ZPZULfNb+m9hAiEIsWdi8Wx04mcmaa2ftdWsUKo=",
+    "h1:hCCSjeSMrt6/hS6byqecfDVHBgiwD3BCUy1YtJJl4So=",
     "zh:02327ad31c998d9d55bafd280a4b1bd3702b496e49f53fad30823712cc85368a",
     "zh:05882df6b5b59d23e2aa0c454caea84fcc35e435eb925e18293415260b4850c8",
     "zh:0c0d6309abcfa24f0775df9bff81cb8f63029fead66956316d7cfa837c231873",
@@ -27,6 +28,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   constraints = "2.9.0"
   hashes = [
     "h1:3M1gPJ2W3qtYr6do1HkH5l03kSEHIYMQ97W2tP59dYY=",
+    "h1:D5BLFN82WndhQZQleXE5rO0hUDnlyqb60XeUJKDhuo4=",
     "h1:fEDID5J/9ret/sLpOSNAu98F/ZBEZhOmL0Leut7m5JU=",
     "zh:1471cb45908b426104687c962007b2980cfde294fa3530fabc4798ce9fb6c20c",
     "zh:1572e9cec20591ec08ece797b3630802be816a5adde36ca91a93359f2430b130",
@@ -47,6 +49,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.18.1"
   constraints = "2.18.1"
   hashes = [
+    "h1:h4ezMuMNyKRMRhlrErph7QOUToc77U+rVKdR48w6tr8=",
     "h1:vBRsQjT8QeFe8C9yJ1PR43wzX4hM5UssxlHkPPo34gU=",
     "h1:y4VED+vsulAqE7YbQC7x1XXrzvi/dEIjupttSyzSA/M=",
     "zh:09d69d244f5e688d9b1582112aa5d151c5336278e43d39c88ae920c26536b753",
@@ -68,6 +71,7 @@ provider "registry.terraform.io/statuscakedev/statuscake" {
   version     = "2.0.4"
   constraints = "2.0.4"
   hashes = [
+    "h1:IoK/VG1iAyMnsR1mgG0Ku1F/NlkJEnzfADCfZAFRYQ0=",
     "h1:ZWhLMoREWISsr9NkKNGdqeCWV0yr9cU+DOWSa5l8ZeA=",
     "h1:y2dthcfU+b/p0q6ZCa2u61cp1QnmeX1k63cylKEQ+KY=",
     "zh:0a0962aff7c3112c8b32182e3e80974f1d334a73570450c8a834cde905b804f6",


### PR DESCRIPTION
### Context
We need a way to enable Azure AD authentication with Azure RBAC. 
We also need a way to disable local account.
Both the above properties, must be configurable 

### Changes proposed in this pull request

- Add 3 new variables, with default values set to false (azure_rabac_enabled, role_based_access_control_enabled and local_account_disabled)
- Add another managed variable , which has a default value of true
- Add code to main.tf to support above variables

### Implementing these changes
1, Deployed cluster, before code changes - Cluster was deployed using local account with Kubernetes RBAC
2, Added dynamic code block into main.tf and added variable into variable.tf
3, Rerun apply - No changes were made to cluster
4, Set azure_rabac_enabled, role_based_access_control_enabled and local_account_disabled to true in config/development.tfvars.json
5, Rerun apply, cluster was deployed using Azure AD authentication with Azure RBAC
**Note, the cluster was destroyed and created during step 5**

### Next Steps
1, Review current code changes
2, Create role binding [Microsoft learn: role bindings](https://learn.microsoft.com/en-us/azure/aks/azure-ad-rbac?tabs=portal#create-the-aks-cluster-resources-for-sres)
3, Test authentication with applications

### Notes
- Commonly, role bindings are assigned to Active Directory groups. Individual identities and then assigned to group, as required. (step 2 above)
- Commonly, a AD group if created for admins [admin_group_object_ids](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#admin_group_object_ids). Currently, this isn't implemented


