### PR TITLE
[294] Confirm make commands to non-dev environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,18 +6,23 @@ development:
 	$(eval include cluster/config/development.sh)
 
 test:
+	$(if ${CONFIRM_TEST}, , $(error Missing CONFIRM_TEST=yes))
 	$(eval include cluster/config/test.sh)
 
 platform-test:
+	$(if ${CONFIRM_PLATFORM_TEST}, , $(error Missing CONFIRM_PLATFORM_TEST=yes))
 	$(eval include cluster/config/platform-test.sh)
 
 production:
-	 $(eval include cluster/config/production.sh)
+	$(if ${CONFIRM_PRODUCTION}, , $(error Missing CONFIRM_PRODUCTION=yes))
+	$(eval include cluster/config/production.sh)
 
 prod-domain:
+	$(if ${CONFIRM_PROD_DOMAIN}, , $(error Missing CONFIRM_PROD_DOMAIN=yes))
 	$(eval include custom_domains/config/prod-domain.sh)
 
 dev-domain:
+	$(if ${CONFIRM_DEV_DOMAIN}, , $(error Missing CONFIRM_DEV_DOMAIN=yes))
 	$(eval include custom_domains/config/dev-domain.sh)
 
 set-azure-account:

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ make development terraform-plan ENVIRONMENT=cluster1
 #### Permanent environments: platform-test, test, production
 
 ```
-make <environment> terraform-{plan/apply}
+make <environment> terraform-{plan/apply} CONFIRM...
 ```
 
 e.g.
 ```
-make test terraform-plan
+make test terraform-plan CONFIRM_TEST=yes
 ```
 
 ### kubectl


### PR DESCRIPTION
## What
Avoid human mistakes when running on command line by forcing a separate command line confirmation for each environment

## How to review
Run: `make test terraform-plan`
It should only work with `CONFIRM_TEST=something`