### PR TITLE
[261] Temporary certificate issue

### DIFF
--- a/cluster/terraform_kubernetes/config/development.tfvars.json
+++ b/cluster/terraform_kubernetes/config/development.tfvars.json
@@ -1,6 +1,7 @@
 {
   "cip_tenant": true,
   "namespaces": [
+    "infra",
     "development",
     "qa",
     "staging",

--- a/cluster/terraform_kubernetes/config/platform-test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/platform-test.tfvars.json
@@ -1,6 +1,7 @@
 {
     "cip_tenant": true,
     "namespaces": [
+      "infra",
       "development",
       "qa",
       "staging",

--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -1,6 +1,10 @@
 {
   "cip_tenant": true,
-  "namespaces": ["bat-production", "tra-production"],
+  "namespaces": [
+    "infra",
+    "bat-production",
+    "tra-production"
+  ],
   "cluster_kv": "s189p01-tsc-pd-kv",
   "statuscake_alerts": {
     "tscluster-production": {

--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -15,5 +15,10 @@
         282453
       ]
     }
-  }
+  },
+  "welcome_app_hostnames": [
+    "www.teacherservices.cloud",
+    "test.teacherservices.cloud",
+    "development.teacherservices.cloud"
+  ]
 }

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -1,6 +1,7 @@
 {
   "cip_tenant": true,
   "namespaces": [
+    "infra",
     "bat-qa",
     "bat-staging",
     "tra-development",

--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -27,6 +27,12 @@ resource "helm_release" "ingress-nginx" {
     value = "default/cert-secret"
     type  = "string"
   }
+  # Disable HTTP port 80 on the Azure load balancer
+  set {
+    name  = "controller.service.enableHttp"
+    value = "false"
+    type  = "auto"
+  }
   set {
     name  = "controller.config.proxy-buffer-size"
     value = "8k"

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -41,6 +41,12 @@ variable "clone_cluster" {
   default = false
 }
 
+variable "welcome_app_hostnames" {
+  description = "Full hostname to enable the welcome app on this domain"
+  type        = list(any)
+  default     = []
+}
+
 locals {
   cluster_name = (
     var.cip_tenant ?
@@ -58,5 +64,7 @@ locals {
   )
   api_token = data.azurerm_key_vault_secret.statuscake_secret.value
 
-  azure_credentials = try(jsondecode(var.azure_sp_credentials_json), null)
+  azure_credentials     = try(jsondecode(var.azure_sp_credentials_json), null)
+  welcome_app_name      = "welcome-app"
+  welcome_app_namespace = "infra"
 }

--- a/cluster/terraform_kubernetes/welcome_app.tf
+++ b/cluster/terraform_kubernetes/welcome_app.tf
@@ -1,0 +1,95 @@
+resource "kubernetes_deployment" "welcome_app" {
+  count = length(var.welcome_app_hostnames) > 0 ? 1 : 0
+
+  metadata {
+    name      = local.welcome_app_name
+    namespace = local.welcome_app_namespace
+  }
+  spec {
+    replicas = 1
+    selector {
+      match_labels = {
+        app = local.welcome_app_name
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app = local.welcome_app_name
+        }
+      }
+      spec {
+        node_selector = {
+          "teacherservices.cloud/node_pool" = "applications"
+          "kubernetes.io/os"                = "linux"
+        }
+        container {
+          name  = local.welcome_app_name
+          image = "nginx"
+
+          resources {
+            requests = {
+              cpu    = "100m"
+              memory = "64M"
+            }
+            limits = {
+              cpu    = "100m"
+              memory = "64M"
+            }
+          }
+          port {
+            container_port = 80
+          }
+        }
+      }
+    }
+  }
+}
+
+
+resource "kubernetes_service" "welcome_app" {
+  count = length(var.welcome_app_hostnames) > 0 ? 1 : 0
+
+  metadata {
+    name      = local.welcome_app_name
+    namespace = local.welcome_app_namespace
+  }
+  spec {
+    type = "ClusterIP"
+    port {
+      port        = 80
+      target_port = 80
+    }
+    selector = {
+      app = local.welcome_app_name
+    }
+  }
+}
+
+resource "kubernetes_ingress_v1" "welcome_app" {
+  for_each = toset(var.welcome_app_hostnames)
+
+  wait_for_load_balancer = true
+  metadata {
+    name      = local.welcome_app_name
+    namespace = local.welcome_app_namespace
+  }
+  spec {
+    ingress_class_name = "nginx"
+    rule {
+      host = each.value
+      http {
+        path {
+          backend {
+            service {
+              name = kubernetes_service.welcome_app[0].metadata[0].name
+              port {
+                number = kubernetes_service.welcome_app[0].spec[0].port[0].port
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What
Review apps under *.test.teacherservices.cloud keep getting blocked when users are on the DfE network. This brings a number of fixes required for Palo Alto to trust the domains.

- Provide full certificate chain. This requires string manipulation as the certificate chain returned by the terraform data source is in the wrong order. See azurerm issue: https://github.com/hashicorp/terraform-provider-azurerm/issues/21467
- Disable HTTP port
- Deploy websites on top domains

## How to review
Already manually deployed to platform-test and test

Test in dev:
- Deploy a review app to cluster2 (such as https://apply-review-4231.cluster2.development.teacherservices.cloud/)
- Make sure you're on the DfE network
- Access immediately
- There should be no error