### PR TITLE
Upgrade production kubernetes to version 1.25.6

### DIFF
--- a/cluster/terraform_aks_cluster/config/production.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/production.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.24.9",
+  "kubernetes_version": "1.25.6",
   "default_node_pool": {
     "node_count": 3,
-    "orchestrator_version": "1.24.9"
+    "orchestrator_version": "1.25.6"
   },
   "node_pools": {
     "apps1": {
@@ -13,7 +13,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.24.9"
+      "orchestrator_version": "1.25.6"
     }
   }
 }


### PR DESCRIPTION
**Context**

- We should endeavour to keep the AKS Clusters up to date. Current Kubernetes version is 1.24.9 which is being upgraded to 1.25.6
- 
**Changes proposed in this pull request**

- Bump Kubernetes and orchestrator version to 1.25.6
