### PR TITLE
Fix konduit to work with module app naming

### DIFF
--- a/scripts/konduit.sh
+++ b/scripts/konduit.sh
@@ -92,7 +92,7 @@ init_setup() {
    fi
 
    # Get the deployment namespace
-   NAMESPACE=$(kubectl get deployments -A | grep "${INSTANCE}" | awk '{print $1}')
+   NAMESPACE=$(kubectl get deployments -A | grep "${INSTANCE} " | awk '{print $1}')
 
    # Set service ports
    DB_PORT=5432


### PR DESCRIPTION
Small fix to allow konduit to work with the new terraform module naming standard

# How to test

run against register resources using external module
run against apply resources not using external module
