### PR TITLE
299-create-ingress-public-ip-separately

### DIFF
--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -94,8 +94,8 @@ resource "helm_release" "ingress-nginx-clone" {
 }
 resource "azurerm_public_ip" "public-ip" {
   name                = "${var.resource_prefix}-tsc-aks-nodes-${var.environment}-pip"
-  location            = data.azurerm_resource_group.node_resource_group.location
-  resource_group_name = data.azurerm_resource_group.node_resource_group.name
+  location            = data.azurerm_resource_group.nodes_resource_group.location
+  resource_group_name = data.azurerm_resource_group.nodes_resource_group.name
   allocation_method   = "Static"
   sku                 = "Standard"
 

--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -67,6 +67,10 @@ resource "helm_release" "ingress-nginx" {
     value = "true"
     type  = "string"
   }
+  set {
+    name  = "controller.service.loadBalancerIP"
+    value = azurerm_public_ip.public-ip.ip_address
+  }
 }
 
 resource "helm_release" "ingress-nginx-clone" {
@@ -87,5 +91,15 @@ resource "helm_release" "ingress-nginx-clone" {
       type  = set.value["type"]
     }
   }
+}
+resource "azurerm_public_ip" "public-ip" {
+  name                = "ingres-controller-pip"
+  location            = data.azurerm_resource_group.resource-grooup.location
+  resource_group_name = data.azurerm_resource_group.resource-grooup.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
 
+}
+data "azurerm_resource_group" "resource-grooup" {
+  name = "${var.resource_prefix}-tsc-aks-nodes-${var.environment}-rg"
 }

--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -93,13 +93,13 @@ resource "helm_release" "ingress-nginx-clone" {
   }
 }
 resource "azurerm_public_ip" "public-ip" {
-  name                = "ingres-controller-pip"
-  location            = data.azurerm_resource_group.resource-grooup.location
-  resource_group_name = data.azurerm_resource_group.resource-grooup.name
+  name                = "${var.resource_prefix}-tsc-aks-nodes-${var.environment}-pip"
+  location            = data.azurerm_resource_group.node_resource_group.location
+  resource_group_name = data.azurerm_resource_group.node_resource_group.name
   allocation_method   = "Static"
   sku                 = "Standard"
 
 }
-data "azurerm_resource_group" "resource-grooup" {
+data "azurerm_resource_group" "nodes_resource_group" {
   name = "${var.resource_prefix}-tsc-aks-nodes-${var.environment}-rg"
 }


### PR DESCRIPTION
### Context
When the cluster is recreated, the public IP changes and the *teacherservices.cloud domain must be updated.
Instead, we could create the public IP via terraform and configure the ingress controller to use it.

### Changes proposed in this pull request

- Added new public ip resource to the ingress controller tf file
- Set the  load balancer ip for the ingress controller helm release to the new public ip 


### Review these changes

- Deploy the cluster 
- Deploy an app i.e. register 
- Confirm everything is working 