### PR TITLE
[348] Increase ingress-nginx client body size to 8 MB

### DIFF
--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -33,6 +33,12 @@ resource "helm_release" "ingress-nginx" {
     value = "false"
     type  = "auto"
   }
+  # Allow POST requests with large body. Prevent error 413: Request entity too large
+  set {
+    name  = "controller.config.proxy-body-size"
+    value = "8m"
+    type  = "string"
+  }
   set {
     name  = "controller.config.proxy-buffer-size"
     value = "8k"


### PR DESCRIPTION
## What
Required to prevent "413: Request entity too large" when uploading large files via HTTP POST

## Review
Already deployed to the test cluster