### PR TITLE
299 migrate to public ip addresses for ingress and egress

### DIFF
--- a/custom_domains/terraform/infrastructure/workspace_variables/tscp.tfvars.json
+++ b/custom_domains/terraform/infrastructure/workspace_variables/tscp.tfvars.json
@@ -5,19 +5,19 @@
             "front_door_name": "s189p01-tscdomains-fd",
             "a-records": {
                 "*.platform-test": {
-                    "target": "20.49.212.39"
+                    "target": "20.108.183.129"
                 },
                 "*.test": {
-                    "target": "52.151.120.89"
+                    "target": "20.117.154.223"
                 },
                 "*": {
-                    "target": "20.49.225.59"
+                    "target": "51.142.104.254"
                 },
                 "test": {
-                    "target": "20.49.225.59"
+                    "target": "51.142.104.254"
                 },
                 "platform-test": {
-                    "target": "20.49.225.59"
+                    "target": "51.142.104.254"
                 }
             }
         }


### PR DESCRIPTION
### Context
When the cluster is recreated, the public IP changes and the *teacherservices.cloud domain must be updated.
Instead, we could create the public IP via terraform and configure the ingress controller to use it. 
Same goes for Egress IP Address so this has also been switched to Azure Public IP Address. 

### Changes proposed in this pull request

- Added new public ip resource to the ingress controller tf file
- Set the  load balancer ip for the ingress controller helm release to the new public ip 
- Added new Public IP Resource to the main cluster tf file 
- Set the network profile of the main cluster to use this new public ip for egress
- Updated DNS to reflect migrated IPs for ingress and egress for all environments


### Review these changes

- Deploy the cluster in an environment like dev
- Deploy an app i.e. register 
- Confirm everything is working ; can use ```kubectl exec pod_name -n namespace -it -- sh``` to SSH into a pod and run 
```curl ipinfo.io/ip``` to confirm egress IP is definitely working. Can switch DNS zone to use new public ip address of the ingress and access the web app to confirm ingress IP is working