### PR TITLE
[426] Move public IPs to cluster resource group

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ e.g.
 make test terraform-plan CONFIRM_TEST=yes
 ```
 
+### Initial set-up
+When creating a brand new cluster with its own configuration, follow these steps:
+- Create the config files in:
+    - cluster/config
+    - cluster/terraform_aks_cluster/config
+    - cluster/terraform_kubernetes/config
+- Create the new config entry in the Makefile
+- Create low-level terraform resources: `make <config> validate-azure-resources` and `make <config> deploy-azure-resources`
+- Request the Cloud Engineering Team to assign role "Network Contributor" to the new managed identity on the new resource group
+
 ### kubectl
 - Follow the [kubectl documentation](https://kubernetes.io/docs/tasks/tools/#kubectl) to install it
 - Configure the credentials using the `get-cluster-credentials` make command. Example:

--- a/cluster/terraform_aks_cluster/main.tf
+++ b/cluster/terraform_aks_cluster/main.tf
@@ -104,7 +104,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "node_pools_clone" {
 resource "azurerm_public_ip" "egress-public-ip" {
   name                = "${var.resource_prefix}-tsc-aks-nodes-${var.environment}-egress-pip"
   location            = data.azurerm_resource_group.cluster.location
-  resource_group_name = local.node_resource_group_name
+  resource_group_name = data.azurerm_resource_group.cluster.name
   allocation_method   = "Static"
   sku                 = "Standard"
 

--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -97,14 +97,14 @@ resource "helm_release" "ingress-nginx-clone" {
 
 resource "azurerm_public_ip" "ingress-public-ip" {
   name                = "${var.resource_prefix}-tsc-aks-nodes-${var.environment}-ingress-pip"
-  location            = data.azurerm_resource_group.nodes_resource_group.location
-  resource_group_name = data.azurerm_resource_group.nodes_resource_group.name
+  location            = data.azurerm_resource_group.resource_group.location
+  resource_group_name = data.azurerm_resource_group.resource_group.name
   allocation_method   = "Static"
   sku                 = "Standard"
 
   lifecycle { ignore_changes = [tags] }
 }
 
-data "azurerm_resource_group" "nodes_resource_group" {
-  name = "${var.resource_prefix}-tsc-aks-nodes-${var.environment}-rg"
+data "azurerm_resource_group" "resource_group" {
+  name = var.resource_group_name
 }

--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -14,6 +14,13 @@ resource "helm_release" "ingress-nginx" {
     value = "/healthz"
     type  = "string"
   }
+  # Resource group of the ingress public IP
+  # The cluster managed identity must have Network Contributor role on the resource group
+  set {
+    name  = "controller.service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-resource-group"
+    value = azurerm_public_ip.ingress-public-ip.resource_group_name
+    type  = "string"
+  }
   # Route requests from the load balancer to the ingress pods on the same node instead of adding one more hop to the node with most pods.
   # This preserves the client IP and removes a hop. It potentially creates a traffic imbalance but this should have no effect for us
   # as we should have many well distributed ingress pods.

--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -21,6 +21,12 @@ resource "helm_release" "ingress-nginx" {
     value = azurerm_public_ip.ingress-public-ip.resource_group_name
     type  = "string"
   }
+  # Ingress IP
+  set {
+    name  = "controller.service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-ipv4"
+    value = azurerm_public_ip.ingress-public-ip.ip_address
+    type  = "string"
+  }
   # Route requests from the load balancer to the ingress pods on the same node instead of adding one more hop to the node with most pods.
   # This preserves the client IP and removes a hop. It potentially creates a traffic imbalance but this should have no effect for us
   # as we should have many well distributed ingress pods.
@@ -73,11 +79,6 @@ resource "helm_release" "ingress-nginx" {
     name  = "controller.config.compute-full-forwarded-for"
     value = "true"
     type  = "string"
-  }
-  # Use static Public IP for load balancer ingress
-  set {
-    name  = "controller.service.loadBalancerIP"
-    value = azurerm_public_ip.ingress-public-ip.ip_address
   }
 }
 


### PR DESCRIPTION
## What
The egress public IP is currently deployed to the nodes resource group. This caused a circular dependency:
Egress public IP -> Nodes resource group -> AKS cluster -> Egress public IP
This blocked creating new dev clusters.

Creating in the pre-existing cluster resource group removes this dependency.

## How to review
Deploy a dev cluster

## Before merging
Follow the process in https://hedgedoc.teacherservices.cloud/OeejNnlrQzWfcPQd6Cbjtw?edit to move the IPs manually and update the terraform state.