### PR TITLE
334-upgrade-test-clusters-to-1.26.3

### DIFF
--- a/cluster/terraform_aks_cluster/config/test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/test.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.25.6",
+  "kubernetes_version": "1.26.3",
   "default_node_pool": {
     "node_count": 2,
-    "orchestrator_version": "1.25.6"
+    "orchestrator_version": "1.26.3"
   },
   "node_pools": {
     "apps1": {
@@ -13,7 +13,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.25.6"
+      "orchestrator_version": "1.26.3"
     }
   }
 }


### PR DESCRIPTION
Upgrade the current version of AKS test cluster to version 1.26.3