### PR TITLE
509-update-ingress-nginx

### DIFF
--- a/cluster/terraform_kubernetes/config/development.tfvars.json
+++ b/cluster/terraform_kubernetes/config/development.tfvars.json
@@ -12,5 +12,6 @@
   "cluster_kv": "s189d01-tsc2-dv-kv",
   "welcome_app_hostnames": [
     "www.cluster1.development.teacherservices.cloud"
-  ]
+  ],
+  "ingress_nginx_version": "4.7.1"
 }

--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -2,7 +2,7 @@ resource "helm_release" "ingress-nginx" {
   name       = "ingress-nginx"
   repository = "https://kubernetes.github.io/ingress-nginx"
   chart      = "ingress-nginx"
-  version    = "4.4.0"
+  version    = var.ingress_nginx_version
 
   # The first part of the name with simple dots is the keys path in the values.yml file e.g. controller.service.annotations
   # The last part is the final key e.g. service\\.beta\\.kubernetes\\.io/azure-load-balancer-health-probe-request-path

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -47,6 +47,12 @@ variable "welcome_app_hostnames" {
   default     = []
 }
 
+variable "ingress_nginx_version" {
+  description = "Version of the ingress-nginx helm chart to use"
+  type        = string
+  default     = "4.4.0"
+}
+
 locals {
   cluster_name = (
     var.cip_tenant ?


### PR DESCRIPTION
Update the Ingress Nginx helm charts to version 4.7.1. Add environment specific variables
Introduce the bump in version to Development Cluster
