### PR TITLE
[501] Add get-cluster-credentials to new service template

### DIFF
--- a/templates/new_service/Makefile
+++ b/templates/new_service/Makefile
@@ -7,10 +7,10 @@ SERVICE_SHORT=#SERVICE_SHORT#
 DOCKER_REPOSITORY=#DOCKER_REPOSITORY#
 
 .PHONY: development
-development:
+development: test-cluster
 	$(eval include global_config/development.sh)
 
-production:
+production: production-cluster
 	$(if $(or ${SKIP_CONFIRM}, ${CONFIRM_PRODUCTION}), , $(error Missing CONFIRM_PRODUCTION=yes))
 	$(eval include global_config/production.sh)
 
@@ -100,3 +100,14 @@ domains-plan: domains-init
 
 domains-apply: domains-init
 	terraform -chdir=terraform/domains/environment_domains apply -var-file config/${CONFIG}.tfvars.json ${AUTO_APPROVE}
+
+test-cluster:
+	$(eval CLUSTER_RESOURCE_GROUP_NAME=s189t01-tsc-ts-rg)
+	$(eval CLUSTER_NAME=s189t01-tsc-test-aks)
+
+production-cluster:
+	$(eval CLUSTER_RESOURCE_GROUP_NAME=s189p01-tsc-pd-rg)
+	$(eval CLUSTER_NAME=s189p01-tsc-production-aks)
+
+get-cluster-credentials: set-azure-account
+	az aks get-credentials --overwrite-existing -g ${CLUSTER_RESOURCE_GROUP_NAME} -n ${CLUSTER_NAME}


### PR DESCRIPTION
## What
Add get-cluster-credentials make command so it can be called from the service repository

## How to review
- cd templates/new_service
- make development get-cluster-credentials
- make production get-cluster-credentials