### PR TITLE
Add low priority class and deployment

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -26,5 +26,6 @@
     "platform-test.teacherservices.cloud",
     "development.teacherservices.cloud"
   ],
-  "ingress_nginx_version": "4.7.1"
+  "ingress_nginx_version": "4.7.1",
+  "enable_lowpriority_app": true
 }

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -29,5 +29,8 @@
   "welcome_app_hostnames": [
     "www.test.teacherservices.cloud"
   ],
-  "ingress_nginx_version": "4.7.1"
+  "ingress_nginx_version": "4.7.1",
+  "enable_lowpriority_app": true,
+  "lowpriority_app_cpu": "0.1",
+  "lowpriority_app_mem": "1Gi"
 }

--- a/cluster/terraform_kubernetes/lowpriority_app.tf
+++ b/cluster/terraform_kubernetes/lowpriority_app.tf
@@ -1,0 +1,55 @@
+resource "kubernetes_priority_class_v1" "lowpriority" {
+  count = var.enable_lowpriority_app ? 1 : 0
+
+  metadata {
+    name = "lowpriority"
+  }
+
+  value = -1
+}
+
+resource "kubernetes_deployment" "lowpriority_app" {
+  count = var.enable_lowpriority_app ? 1 : 0
+
+  metadata {
+    name      = local.lowpriority_app_name
+    namespace = local.lowpriority_app_namespace
+  }
+  spec {
+    replicas = var.lowpriority_app_replicas
+    selector {
+      match_labels = {
+        app = local.lowpriority_app_name
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app = local.lowpriority_app_name
+        }
+      }
+      spec {
+        node_selector = {
+          "teacherservices.cloud/node_pool" = "applications"
+          "kubernetes.io/os"                = "linux"
+        }
+        priority_class_name = "lowpriority"
+        container {
+          name  = local.lowpriority_app_name
+          image = "k8s.gcr.io/pause"
+
+          resources {
+            requests = {
+              cpu    = var.lowpriority_app_cpu
+              memory = var.lowpriority_app_mem
+            }
+            limits = {
+              cpu    = 1
+              memory = var.lowpriority_app_mem
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -53,6 +53,24 @@ variable "ingress_nginx_version" {
   default     = "4.4.0"
 }
 
+variable "enable_lowpriority_app" {
+  type    = bool
+  default = false
+}
+
+variable "lowpriority_app_cpu" {
+  default = "1"
+}
+
+variable "lowpriority_app_mem" {
+  default = "1500Mi"
+}
+
+variable "lowpriority_app_replicas" {
+  default = 3
+}
+
+
 locals {
   cluster_name = (
     var.cip_tenant ?
@@ -70,7 +88,9 @@ locals {
   )
   api_token = data.azurerm_key_vault_secret.statuscake_secret.value
 
-  azure_credentials     = try(jsondecode(var.azure_sp_credentials_json), null)
-  welcome_app_name      = "welcome-app"
-  welcome_app_namespace = "infra"
+  azure_credentials         = try(jsondecode(var.azure_sp_credentials_json), null)
+  welcome_app_name          = "welcome-app"
+  welcome_app_namespace     = "infra"
+  lowpriority_app_name      = "lowpriority-app"
+  lowpriority_app_namespace = "infra"
 }

--- a/documentation/lowpriority-app.md
+++ b/documentation/lowpriority-app.md
@@ -1,0 +1,56 @@
+# Low Priority application
+
+The lowpriority-app deployment reserves cpu and memory on each node, which will be preempted by any standard deployment when there is no immediately available space.
+
+The lowpriority-app will then be redeployed when new nodes have been added by the cluster autoscaler.
+
+This should lessen the number of deployments that fail waiting for new nodes to be started when there is no immediately available capacity.
+
+## Technical Details
+
+Application deployment pods have no priority class with default priority 0.
+
+So we create a lowpriority class with priority -1.
+
+Then deploy a lowpriority app that uses this class.
+
+This lowpriority app will reserve cpu/memory and will be preempted when another app needs capacity
+
+and there is no immediately available resources
+
+https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#how-to-use-priority-and-preemption
+
+## To enable for a cluster
+
+In ${cluster-env}.tfvars.json
+
+- set "enable_lowpri_app": true
+- override defaults if required (see below)
+```
+variable "lowpriority_app_cpu" { default = "1" }
+```
+This should match the cpu request value for a cluster
+
+```
+variable "lowpriority_app_mem" { default = "1500Mi" }
+```
+This should at least equal the max_memory of the largest service on that cluster
+
+```
+variable "lowpriority_app_replicas" { default = 3 }
+```
+We use 3 availability zones, so the default reserves space in each az.
+This can be increased if deployments continue to be affected by insufficient capacity.
+
+## Temporary reservation increase
+
+There may be times when you need to temporarily increase the amount of reserved space,
+
+e.g. scheduled increase in replicas for a service
+
+in this case, you can simply scale the number of replicas of the lowpriority app.
+
+```kubectl -n infra scale deployment/lowpriority-app --replicas n```
+where n is the number of replicas required
+
+Reset back to the default when the increase is no longer required.


### PR DESCRIPTION
### Adds a lowpriority class and lowpri-app deployment 

The lowpri-app deployment reserves cpu and memory on each replica (default x3) which will be preempted by any standard deployment when there is no immediately available space. The lowpri-app will then be redeployed when new nodes have been added by the cluster autoscaler. 
This should lessen the number of deployments that fail waiting for new nodes to be started when there is no immediately available capacity.

**Before merge,**
remove `"enable_lowpri_app": true` from development.tfvars.json
as this should only be enabled in dev clusters when testing

### Testing run against development cluster1

Lowpri-app deployed (3 replicas)

![image](https://github.com/DFE-Digital/teacher-services-cloud/assets/94844345/4be05129-f922-47b3-9140-3be0dec272dc)

There are 5 nodes in the cluster, and none have more than 0.5 cpu available.
Now we submit a new default priority app register-pr-99rm that has a cpu requirement (request) of 1 cpu per replica (x3)
The lowpri-app is immediately preempted, and the new app takes the capacity that was held by it.

![image](https://github.com/DFE-Digital/teacher-services-cloud/assets/94844345/5a4f46cb-f4b7-4f24-b575-2793b5b73c62)

The lowpri-app waits for the autoscaler to add new nodes, and then it is started 

![image](https://github.com/DFE-Digital/teacher-services-cloud/assets/94844345/cbab6b5d-5c25-4f81-8278-de58d40bbf6b)

### To test in dev

Increase apps1 nodepool max_count from 3 to 9 in the selected dev cluster
`make development terraform-apply ENVIRONMENT=clusterx` to deploy lowpri class and app
Then deploy an app with cpu min (request) 1 and x replicas, while monitoring the deployments in your cluster
