### PR TITLE
Increase proxy-buffer-size from 8k to 24k for git

### DIFF
--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -52,9 +52,12 @@ resource "helm_release" "ingress-nginx" {
     value = "8m"
     type  = "string"
   }
+  # Sets the size of the buffer used for reading the first part of the response received from the proxied server.
+  # Needs to be larger than the response header or nginx will return an error for the request
+  # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#proxy-buffer-size
   set {
     name  = "controller.config.proxy-buffer-size"
-    value = "8k"
+    value = "24k"
     type  = "string"
   }
   set {


### PR DESCRIPTION
## Context
Git app generates a larger response header than nginx currently allows
Requests return 'upstream sent too big header while reading response header from upstream' in the nginx logs

## Changes proposed in this pull request
Increase proxy-buffer-size from 8k to 24k

## Guidance to review
make test|platform-test|production terraform-plan CONFIRM_env=yes

Change has already been made manually in the test cluster
kubectl describe cm/ingress-nginx-controller

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
