### PR TITLE
Removed retention policy under azurerm_monitor_diagnostic_setting

### DIFF
--- a/cluster/terraform_aks_cluster/analytics.tf
+++ b/cluster/terraform_aks_cluster/analytics.tf
@@ -18,51 +18,21 @@ resource "azurerm_monitor_diagnostic_setting" "aks_system_logs" {
   # It's currently set to this as default and can be expanded upon
   enabled_log {
     category = "kube-apiserver"
-
-    retention_policy {
-      enabled = true
-      days    = 10
-    }
   }
   enabled_log {
     category = "kube-audit-admin"
-
-    retention_policy {
-      enabled = true
-      days    = 10
-    }
   }
   enabled_log {
     category = "kube-controller-manager"
-
-    retention_policy {
-      enabled = true
-      days    = 10
-    }
   }
   enabled_log {
     category = "kube-scheduler"
-
-    retention_policy {
-      enabled = true
-      days    = 10
-    }
   }
   enabled_log {
     category = "cluster-autoscaler"
-
-    retention_policy {
-      enabled = true
-      days    = 10
-    }
   }
   enabled_log {
     category = "cloud-controller-manager"
-
-    retention_policy {
-      enabled = true
-      days    = 10
-    }
   }
   metric {
     category = "AllMetrics"


### PR DESCRIPTION

## Context
Terraform Apply is failing , due to deprication of retention_policy under aks_systems_logs

## Changes proposed in this pull request
Removing retention_policy under azurerm_monitor_diagnostic_setting

## Guidance to review
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting#retention_policy

 
## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
