### PR TITLE
 Added new name spaces for techinical migration

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -7,7 +7,8 @@
     "infra",
     "srtl-production",
     "tra-production",
-    "tv-production"
+    "tv-production",
+    "tech-arch-production"
   ],
   "cluster_kv": "s189p01-tsc-pd-kv",
   "statuscake_alerts": {

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -12,7 +12,8 @@
     "tra-development",
     "tra-test",
     "tv-development",
-    "tv-staging"
+    "tv-staging",
+    "tech-arch-development"
   ],
   "cluster_kv": "s189t01-tsc-ts-kv",
   "ingress_cert_name": "test-teacherservices-cloud-2",


### PR DESCRIPTION


## Context
Changes related to Technical Guidence migration to AKS.

## Changes proposed in this pull request
Creating New name spaces for Technical Guidence.

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
