### PR TITLE
platform test AKS version upgraded to 1.26.6

### DIFF
--- a/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.26.3",
+  "kubernetes_version": "1.26.6",
   "default_node_pool": {
     "node_count": 2,
-    "orchestrator_version": "1.26.3"
+    "orchestrator_version": "1.26.6"
   },
   "node_pools": {
     "apps1": {
@@ -12,7 +12,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.26.3"
+      "orchestrator_version": "1.26.6"
     }
   }
 }


### PR DESCRIPTION
 
## Context
platform test AKS version upgraded to 1.26.6

## Changes proposed in this pull request
platform test AKS version upgraded to 1.26.6

## Guidance to review

-     - Changes has been applied on Platform-test .
-     -  Check Kubernetes version using the command  kubectl version | grep Server  it should return  Server Version: v1.26.6
-     - Check Nodes version using command `kubectl get nodes` VERSION column should return all nodes 'v1.26.6'
-     - Check liveness of ngnix endpoint   `curl -is https://www.platform-test.teacherservices.cloud/ | grep HTTP ` it should return HTTP status 200

## Before merging
NA

## After merging
NA
## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
