### PR TITLE
topology_spread_constraint added to welcome app

### DIFF
--- a/cluster/terraform_kubernetes/welcome_app.tf
+++ b/cluster/terraform_kubernetes/welcome_app.tf
@@ -23,6 +23,27 @@ resource "kubernetes_deployment" "welcome_app" {
           "teacherservices.cloud/node_pool" = "applications"
           "kubernetes.io/os"                = "linux"
         }
+        topology_spread_constraint {
+          max_skew           = 1
+          topology_key       = "topology.kubernetes.io/zone"
+          when_unsatisfiable = "DoNotSchedule"
+          label_selector {
+            match_labels = {
+              app = local.welcome_app_name
+            }
+          }
+        }
+        topology_spread_constraint {
+          max_skew           = 1
+          topology_key       = "kubernetes.io/hostname"
+          when_unsatisfiable = "ScheduleAnyway"
+          label_selector {
+            match_labels = {
+              app = local.welcome_app_name
+            }
+          }
+        }
+
         container {
           name  = local.welcome_app_name
           image = "nginx"


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
Welcome app pod replicas to spread across multiple node / zone for high availability.

## Changes proposed in this pull request
Added topology spread logic for zone and hostname

## Guidance to review
Changes has been deployed on platform test , This can be tested as below.

- Run the command below to display nodes and the welcome app. The welcome app should be distributed across various nodes
- kubectl get po -n infra -o json -l app=welcome-app | jq '.items[] | {name: .metadata.name, node: .spec.nodeName}' 

## Before merging
NA
## After merging
NA

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
