### PR TITLE
[775] Increase ingress-nginx keepalive to 2 min

### DIFF
--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -60,6 +60,18 @@ resource "helm_release" "ingress-nginx" {
     value = "24k"
     type  = "string"
   }
+  # This ConfigMap setting sets the time, in seconds, during which a keep-alive client connection will stay open on the server side
+  set {
+    name  = "controller.config.keep-alive"
+    value = "120"
+    type  = "auto"
+  }
+  # This ConfigMap setting defines a timeout for reading client request header, in seconds
+  set {
+    name  = "controller.config.client-header-timeout"
+    value = "120"
+    type  = "auto"
+  }
   set {
     name  = "controller.replicaCount"
     value = 20


### PR DESCRIPTION
## Context
We are seeing some connection errors on TRS when using front door. Microsoft support said the keepalive to the backend must be more than 90s. It was 60s by default.

## Changes proposed in this pull request
Set keepalive to 120s
Client header timeout must be increased as well or the connection is stopped

## Guidance to review
Run the script:

```shell
start=`date +%s`
echo -e "GET /  HTTP/1.1\r\nHost:www.cluster1.development.teacherservices.cloud\r\n\r\n" | openssl s_client -connect www.cluster1.development.teacherservices.cloud:443 -servername www.cluster1.development.teacherservices.cloud -ign_eof
end=`date +%s`
runtime=$((end-start))
echo "KeepAlive timeout is around $runtime seconds"
echo "done"
```
It should show about 2min

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
