### PR TITLE
Add common-* namespaces for shared tools and resources

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -2,6 +2,7 @@
   "cip_tenant": true,
   "namespaces": [
     "bat-production",
+    "common-production",
     "cpd-production",
     "git-production",
     "infra",

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -4,6 +4,7 @@
     "infra",
     "bat-qa",
     "bat-staging",
+    "common-development",
     "cpd-development",
     "cpd-test",
     "git-development",


### PR DESCRIPTION
## Context
We're adding this namespace to house at first the GIAS API and in due course other shared things like Tech Docs.

## Changes proposed in this pull request
Add the namespace in test and prod.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
~- [ ] I have attached the pull request to the trello card N/A~
