### PR TITLE
Upgrade helm chart Ingress NGNIX to 4.8.3

### DIFF
--- a/cluster/terraform_aks_cluster/.terraform.lock.hcl
+++ b/cluster/terraform_aks_cluster/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.82.0"
   constraints = "3.82.0"
   hashes = [
+    "h1:Zo/EZdNd8Vubo3rSj5NTU4SwLqArsz1mqtefru/8DpQ=",
     "h1:wIfGA8icS9CbbMfHQFRAUddF2/emdmvJbkTZxfEJTXg=",
     "zh:2042c5485476b0b9dbcebfc01d95e1cec50b37b2c443ffd9824a4fc6a7b293bd",
     "zh:3fc6753c039bac1866b90f5faf5f72edc7470cb64c1e84f830e71931dfced865",

--- a/cluster/terraform_kubernetes/.terraform.lock.hcl
+++ b/cluster/terraform_kubernetes/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.82.0"
   constraints = "3.82.0"
   hashes = [
+    "h1:Zo/EZdNd8Vubo3rSj5NTU4SwLqArsz1mqtefru/8DpQ=",
     "h1:wIfGA8icS9CbbMfHQFRAUddF2/emdmvJbkTZxfEJTXg=",
     "zh:2042c5485476b0b9dbcebfc01d95e1cec50b37b2c443ffd9824a4fc6a7b293bd",
     "zh:3fc6753c039bac1866b90f5faf5f72edc7470cb64c1e84f830e71931dfced865",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   version     = "2.12.0"
   constraints = "2.12.0"
   hashes = [
+    "h1:8EsvI/hOM9Q9ltVhkQfeK2NF4cr0RxHiUPqdmddcKHI=",
     "h1:N29oQNxmZR0tOdpUSeHZCLY/ML0Pa14a+CqDbBApSuw=",
     "zh:08aa5b177db2603a0ecf9728f867cbccbd663f4a3867251729604692c21cd28f",
     "zh:13ce638a3f5f88c9e0da951472619d4449172a3f5cb0332eaba87964456c88ac",
@@ -46,6 +48,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   constraints = "2.24.0"
   hashes = [
     "h1:8Ov9r+eCpuqY9LNjG3I8vKT0hX/FkyzuDxQySZVt9i4=",
+    "h1:Q8+R+wE1XMfJjIixxdBo6qVni01a/P6ceSGJ+kR2z/0=",
     "zh:0ed83ec390a7e75c4990ebce698f14234de2b6204ed9a01cd042bb7ea5f26564",
     "zh:195150e4fdab259c70088528006f4604557a051e037ebe8de64e92840f27e40a",
     "zh:1a334af55f7a74adf033eb871c9fe7e9e648b41ab84321114ef4ca0e7a34fba6",

--- a/cluster/terraform_kubernetes/config/development.tfvars.json
+++ b/cluster/terraform_kubernetes/config/development.tfvars.json
@@ -13,5 +13,5 @@
   "welcome_app_hostnames": [
     "www.cluster1.development.teacherservices.cloud"
   ],
-  "ingress_nginx_version": "4.7.1"
+  "ingress_nginx_version": "4.8.3"
 }

--- a/cluster/terraform_kubernetes/config/platform-test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/platform-test.tfvars.json
@@ -21,5 +21,5 @@
     "welcome_app_hostnames": [
       "www.platform-test.teacherservices.cloud"
     ],
-    "ingress_nginx_version": "4.7.1"
+    "ingress_nginx_version": "4.8.3"
   }

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -31,7 +31,7 @@
   "welcome_app_hostnames": [
     "www.test.teacherservices.cloud"
   ],
-  "ingress_nginx_version": "4.7.1",
+  "ingress_nginx_version": "4.8.3",
   "enable_lowpriority_app": true,
   "lowpriority_app_cpu": "0.1",
   "lowpriority_app_mem": "1Gi"

--- a/documentation/Ingress-controller-upgrade.md
+++ b/documentation/Ingress-controller-upgrade.md
@@ -18,7 +18,7 @@
 
 - To start the upgrade open the file `test.tfvars.json` located at `cluster/terraform_kubernetes/config`
 - This is an oportunity to test changes in test cluster before rolling out to higher environment like prod
-- Set the value of the variable i.e. `"ingress_nginx_version": "4.7.1"`
+- Set the value of the variable i.e. `"ingress_nginx_version": "4.8.3"`
 - Run terraform apply
 
 ```


### PR DESCRIPTION

## Context
Upgrade helm chart Ingress NGNIX to 4.8.3

## Changes proposed in this pull request
update the tfvars files to change the value to 4.8.3

## Guidance to review
<!-- Show how this can be tested or evidence that it is working -->
make platform-test  terraform-apply  CONFIRM_PLATFORM_TEST=yes   