### PR TITLE
upgraded prod nginx helm to VERSION 4.8.3

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -28,6 +28,6 @@
     "platform-test.teacherservices.cloud",
     "development.teacherservices.cloud"
   ],
-  "ingress_nginx_version": "4.7.1",
+  "ingress_nginx_version": "4.8.3",
   "enable_lowpriority_app": true
 }


### PR DESCRIPTION

## Context
Upgrade helm chart Ingress NGNIX to 4.8.3 for prod

## Changes proposed in this pull request
update the tfvars files to change the value to 4.8.3

## Guidance to review
make production terraform-apply CONFIRM_PRODUCTION=yes
