### PR TITLE
upgraded platform test  nginx helm to 4.8.3

### DIFF
--- a/cluster/terraform_kubernetes/config/platform-test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/platform-test.tfvars.json
@@ -21,5 +21,5 @@
     "welcome_app_hostnames": [
       "www.platform-test.teacherservices.cloud"
     ],
-    "ingress_nginx_version": "4.7.1"
+    "ingress_nginx_version": "4.8.3"
   }


### PR DESCRIPTION
## Context
Upgrade helm chart Ingress NGNIX to 4.8.3 for platform test

## Changes proposed in this pull request
update the tfvars files to change the value to 4.8.3

## Guidance to review
make platform-test terraform-apply CONFIRM_PLATFORM_TEST=yes
