### PR TITLE
upgraded dev  nginx helm to 4.8.3

### DIFF
--- a/cluster/terraform_kubernetes/config/development.tfvars.json
+++ b/cluster/terraform_kubernetes/config/development.tfvars.json
@@ -13,5 +13,5 @@
   "welcome_app_hostnames": [
     "www.cluster1.development.teacherservices.cloud"
   ],
-  "ingress_nginx_version": "4.7.1"
+  "ingress_nginx_version": "4.8.3"
 }

--- a/cluster/terraform_kubernetes/config/platform-test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/platform-test.tfvars.json
@@ -21,5 +21,5 @@
     "welcome_app_hostnames": [
       "www.platform-test.teacherservices.cloud"
     ],
-    "ingress_nginx_version": "4.7.1"
+    "ingress_nginx_version": "4.8.3"
   }

--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -28,6 +28,6 @@
     "platform-test.teacherservices.cloud",
     "development.teacherservices.cloud"
   ],
-  "ingress_nginx_version": "4.7.1",
+  "ingress_nginx_version": "4.8.3",
   "enable_lowpriority_app": true
 }

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -31,7 +31,7 @@
   "welcome_app_hostnames": [
     "www.test.teacherservices.cloud"
   ],
-  "ingress_nginx_version": "4.7.1",
+  "ingress_nginx_version": "4.8.3",
   "enable_lowpriority_app": true,
   "lowpriority_app_cpu": "0.1",
   "lowpriority_app_mem": "1Gi"


### PR DESCRIPTION
## Context
Upgrade helm chart Ingress NGNIX to 4.8.3 for platform test

## Changes proposed in this pull request
update the tfvars files to change the value to 4.8.3