### PR TITLE
upgraded dev nginx helm to 4.8.3 on Prod

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -28,6 +28,6 @@
     "platform-test.teacherservices.cloud",
     "development.teacherservices.cloud"
   ],
-  "ingress_nginx_version": "4.7.1",
+  "ingress_nginx_version": "4.8.3",
   "enable_lowpriority_app": true
 }


### PR DESCRIPTION
Trello card

https://trello.com/c/mVhvaQk1/798-upgrade-helm-chart-ingress-ngnix-to-483

## Context
To upgrade the ingress-ngnix to 4.8.3

## Changes proposed in this pull request
ingress-ngnix value in tfvars production is changed to 4.8.3

## Guidance to review
make production terraform-apply CONFIRM_PRODUCTION=yes
