### PR TITLE
Increase terraform timeout on node pools

### DIFF
--- a/cluster/terraform_aks_cluster/main.tf
+++ b/cluster/terraform_aks_cluster/main.tf
@@ -58,6 +58,12 @@ resource "azurerm_kubernetes_cluster_node_pool" "node_pools" {
   vnet_subnet_id        = azurerm_subnet.aks-subnet.id
   zones                 = local.uk_south_availability_zones
   node_labels           = try(each.value.node_labels, {})
+
+  timeouts {
+    create = "180m"
+    update = "180m"
+    delete = "180m"
+  }
 }
 
 resource "azurerm_kubernetes_cluster" "clone" {


### PR DESCRIPTION

## Context
A timeout error occurred whilst updating the node pools - it was found that default timeout is 60 minutes.
We need to allow enough time for updates to complete as well as provide enough time to investigate issues

## Changes proposed in this pull request
Increase the timeouts for Create, Update and Delete to 180 minutes(3 hours) each


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
