### PR TITLE
Updated logic to populate environment in slack message

### DIFF
--- a/.github/workflows/check_sp.yml
+++ b/.github/workflows/check_sp.yml
@@ -47,6 +47,6 @@ jobs:
           SLACK_MESSAGE: |
             The Service Principal *${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Application }}*
             secret *${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Name }}* is due to expire in *${{fromJson(steps.pwsh_check_expire.outputs.json_data).data.ExpiresDays}}* days.
-            Please update the secret in *${{fromJson(steps.pwsh_check_expire.outputs.json_data).data.Environment}}*.
+            Please update the secret in the Github ${{ matrix.data.environment }} environment.
             Details on how to do this can be found here: https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/slack-webhook-integration.md
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## Context
The Slack message environment is missing.

`Please update the secret in **.`

## Changes proposed in this pull request
Fixed in workflow check_sp
## Guidance to review
Slack message should display environment 
`  Please update the secret in *test*.`


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
