### PR TITLE
Upgrade aks cluster to 1.26.6 for test and platform-test

### DIFF
--- a/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.26.6",
+  "kubernetes_version": "1.26.10",
   "default_node_pool": {
     "node_count": 2,
-    "orchestrator_version": "1.26.6"
+    "orchestrator_version": "1.26.10"
   },
   "node_pools": {
     "apps1": {
@@ -12,7 +12,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.26.6"
+      "orchestrator_version": "1.26.10"
     }
   }
 }

--- a/cluster/terraform_aks_cluster/config/test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/test.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.26.6",
+  "kubernetes_version": "1.26.10",
   "default_node_pool": {
     "node_count": 2,
-    "orchestrator_version": "1.26.6"
+    "orchestrator_version": "1.26.10"
   },
   "node_pools": {
     "apps1": {
@@ -13,7 +13,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.26.6"
+      "orchestrator_version": "1.26.10"
     }
   }
 }


### PR DESCRIPTION
## Context
1.26.10 is the next supported version. We should upgrade all clusters to next supported version

## Changes proposed in this pull request
Update platform-test and test clusters to version 1.26.10


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
