### PR TITLE
Lowpriority app cpu requests increased from 0.1 to 0.2

### DIFF
--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -33,6 +33,6 @@
   ],
   "ingress_nginx_version": "4.8.3",
   "enable_lowpriority_app": true,
-  "lowpriority_app_cpu": "0.1",
+  "lowpriority_app_cpu": "0.5",
   "lowpriority_app_mem": "1Gi"
 }


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
https://trello.com/c/UNWoI5f8/885-bug-deployments-are-timing-out-on-the-test-cluster
Increased min CPU for lowpriority app
## Changes proposed in this pull request 

Test tfvars Lowpriority app cpu requests increased from 0.1 to 0.5

## Guidance to review
Lowpriority app cpu requests increased from 0.1 to 0.5 
 
## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
