### PR TITLE
Upgrade AKS cluster version to 1.26.10 for Prod

### DIFF
--- a/cluster/terraform_aks_cluster/config/production.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/production.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.26.6",
+  "kubernetes_version": "1.26.10",
   "default_node_pool": {
     "node_count": 3,
-    "orchestrator_version": "1.26.6"
+    "orchestrator_version": "1.26.10"
   },
   "node_pools": {
     "apps1": {
@@ -13,7 +13,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.26.6"
+      "orchestrator_version": "1.26.10"
     }
   }
 }


### PR DESCRIPTION
## Context

1.26.10 is the next supported version. We should upgrade all clusters to next supported version

## Changes proposed in this pull request
Upgrade production cluster to version 1.26.10

## How to review

1. Connect to the production cluster by running the following make command(within the Teacher Services Cloud repo):
    ``` make production get-cluster-credentials CONFIRM_PRODUCTION=yes ```

1. Run the following kubectl command:
    ``` kubectl get nodes ```

  The node versions should show: v1.26.10

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
