### PR TITLE
added simple onboarding info to docs

### DIFF
--- a/documentation/onboard-service.md
+++ b/documentation/onboard-service.md
@@ -9,11 +9,13 @@ flowchart TD;
     FillForm --> OnboardCall["Arrange a quick intro call via DfE Slack channel #teacher-services-infra <br> to get things explained and meet the team"];
     OnboardCall --> SetUpCall["We will help you request access, and set you up to self serve"];
     SetUpCall --> SetUpComplete["Secure access to platform complete"];
+    SetUpComplete --> ProdReady["Complete the steps in /documentation/production-checklist"]
     GetCoding --> SetUpComplete;
-    SetUpComplete --> Done["Start deploying"] ;
+    ProdReady --> Done["Start deploying"] ;
 ```
 
-Before starting, it is important to capture the information required upfront using the  [Onboarding form](onboard-form-template.md) even if it is subject to change in the future
+Before starting, it is important to capture the information required upfront using the  [Onboarding form](onboard-form-template.md) even if it is subject to change in the future. Also, its really important to
+check the [Production Checklist](production-checklist.md). Your code should then be ready to roll.
 
 
 ## Template

--- a/documentation/onboard-service.md
+++ b/documentation/onboard-service.md
@@ -1,4 +1,18 @@
-# Onboard a new service to AKS
+# Onboard a new service to the Teacher Services AKS cloud platform
+
+Onboarding is pretty straightforward and quick..
+```mermaid
+flowchart TD
+    Start[Start] --> Slack[Say Hi in DfE Slack channel #teacher-services-infra]
+    Slack --> GetCoding[Start generating the code using our template..]
+    Slack --> FillForm[Read this page.. /documentation/onboard-form-template.md <br> and make sure you have all the info.]
+    FillForm --> OnboardCall[Arrange a quick intro call via DfE Slack channel #teacher-services-infra <br> to get things explained and meet the team]
+    OnboardCall --> SetUpCall[We will help you request access, and set you up to self serve]
+    SetUpCall --> SetUpComplete[Secure access to platform complete]
+    GetCoding --> SetUpComplete
+    SetUpComplete --> Done[Start deploying..] 
+```
+
 Before starting, it is important to capture the information required upfront using the  [Onboarding form](onboard-form-template.md) even if it is subject to change in the future
 
 

--- a/documentation/onboard-service.md
+++ b/documentation/onboard-service.md
@@ -2,15 +2,15 @@
 
 Onboarding is pretty straightforward and quick..
 ```mermaid
-flowchart TD
-    Start[Start] --> Slack[Say Hi in DfE Slack channel #teacher-services-infra]
-    Slack --> GetCoding[Start generating the code using our template..]
-    Slack --> FillForm[Read this page.. /documentation/onboard-form-template.md <br> and make sure you have all the info.]
-    FillForm --> OnboardCall[Arrange a quick intro call via DfE Slack channel #teacher-services-infra <br> to get things explained and meet the team]
-    OnboardCall --> SetUpCall[We will help you request access, and set you up to self serve]
-    SetUpCall --> SetUpComplete[Secure access to platform complete]
-    GetCoding --> SetUpComplete
-    SetUpComplete --> Done[Start deploying..] 
+flowchart TD;
+    Start["Start"] --> Slack["Say Hi in DfE Slack channel #teacher-services-infra"];
+    Slack --> GetCoding["Start generating the code using our template"];
+    Slack --> FillForm["Read this page.. /documentation/onboard-form-template.md <br> and make sure you have all the info"];
+    FillForm --> OnboardCall["Arrange a quick intro call via DfE Slack channel #teacher-services-infra <br> to get things explained and meet the team"];
+    OnboardCall --> SetUpCall["We will help you request access, and set you up to self serve"];
+    SetUpCall --> SetUpComplete["Secure access to platform complete"];
+    GetCoding --> SetUpComplete;
+    SetUpComplete --> Done["Start deploying"] ;
 ```
 
 Before starting, it is important to capture the information required upfront using the  [Onboarding form](onboard-form-template.md) even if it is subject to change in the future


### PR DESCRIPTION
A simple change to the docs to make it a bit clearer on how to onboard. Targeted at PDM's, DM's, suppliers, those new to to Teacher Services as well as devs/tech leads etc.