### PR TITLE
Added monitoring namespace to all clusters

### DIFF
--- a/cluster/terraform_kubernetes/config/development.tfvars.json
+++ b/cluster/terraform_kubernetes/config/development.tfvars.json
@@ -1,8 +1,9 @@
 {
   "cip_tenant": true,
   "namespaces": [
-    "infra",
     "development",
+    "infra",
+    "monitoring",
     "qa",
     "staging",
     "test"

--- a/cluster/terraform_kubernetes/config/platform-test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/platform-test.tfvars.json
@@ -1,8 +1,9 @@
 {
     "cip_tenant": true,
     "namespaces": [
-      "infra",
       "development",
+      "infra",
+      "monitoring",
       "qa",
       "staging",
       "test"

--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -6,6 +6,7 @@
     "cpd-production",
     "git-production",
     "infra",
+    "monitoring",
     "srtl-production",
     "tra-production",
     "tv-production",

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -9,6 +9,7 @@
     "cpd-test",
     "git-development",
     "git-test",
+    "monitoring",
     "srtl-development",
     "tra-development",
     "tra-test",


### PR DESCRIPTION
## Trello card
https://trello.com/c/l78negs6/910-create-monitoring-namespace
## Context
 Monitoring namespace is needed before installing monitoring services for each cluster hence added 
 to the cluster

## Changes proposed in this pull request
add monitoring to namespaces entry

## Guidance to review
monitoring entry on tfvars files for each environment
