### PR TITLE
Dev Cluster version Upgraded to 1.27.7

### DIFF
--- a/cluster/terraform_aks_cluster/config/development.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/development.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.26.10",
+  "kubernetes_version": "1.27.7",
   "default_node_pool": {
     "node_count": 1,
-    "orchestrator_version": "1.26.10"
+    "orchestrator_version": "1.27.7"
   },
   "node_pools": {
     "apps1": {
@@ -12,7 +12,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.26.10"
+      "orchestrator_version": "1.27.7"
     }
   },
   "admin_group_id": "f77b2daf-7ff4-4aa5-8138-cf983d0b4a18",

--- a/cluster/terraform_kubernetes/.terraform.lock.hcl
+++ b/cluster/terraform_kubernetes/.terraform.lock.hcl
@@ -7,6 +7,7 @@ provider "registry.terraform.io/eppo/environment" {
   hashes = [
     "h1:1Af95/IhzW16rbX8kSApfrAi8vwc5+7uVbCeyVaGw2E=",
     "h1:J0rtl6GrLyBKYz6PQ5BXsyYfjHbgMEoAHEQQ3u0vPBc=",
+    "h1:pceowuRAKcjLd+g4noIJdX6CBIWavlM4BvRTsGfH0uQ=",
     "zh:00e7a6bf7f0f09cc4871d7f4fee2c943ce61c05b9802365a97703d6c2e63e3dc",
     "zh:018d92e621177d053ed5c32e8220efa8c019852c4d60cc7539683bac28470d9b",
     "zh:12ca5162286b80b7f46bd013ae2007641132d201af12bc6adb872f9a0ff85b7a",


### PR DESCRIPTION

## Context
 https://trello.com/c/5FLQdnck/938-upgrade-clusters-to-kubernetes-1277

## Changes proposed in this pull request
Dev Cluster upgrade from 1.26.10 to 1.27.7

## Guidance to review
Create  dev  cluster from  master, then update cluster following steps provided https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/aks-upgrade.md 


 
## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
