### PR TITLE
Platform test AKS cluster upgraded to 1.27.7

### DIFF
--- a/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.26.10",
+  "kubernetes_version": "1.27.7",
   "default_node_pool": {
     "node_count": 2,
-    "orchestrator_version": "1.26.10"
+    "orchestrator_version": "1.27.7"
   },
   "node_pools": {
     "apps1": {
@@ -12,7 +12,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.26.10"
+      "orchestrator_version": "1.27.7"
     }
   },
   "admin_group_id": "f726cc54-78cb-4c98-89a6-b8e4396afb98",


### PR DESCRIPTION


## Context
 https://trello.com/c/5FLQdnck/938-upgrade-clusters-to-kubernetes-1277

## Changes proposed in this pull request
platform test Cluster upgrade from 1.26.10 to 1.27.7

## Guidance to review
Updated cluster following steps provided https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/aks-upgrade.md 

## Before merging
<!-- Any extra steps like: delete temp commit, send warning, wait after office hours... -->

## After merging
<!-- Any extra steps like: update other PR, apply manually, inform someone... -->

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
