### PR TITLE
Test Cluster version upgrade to 1.27.7

### DIFF
--- a/cluster/terraform_aks_cluster/config/test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/test.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.26.10",
+  "kubernetes_version": "1.27.7",
   "default_node_pool": {
     "node_count": 2,
-    "orchestrator_version": "1.26.10"
+    "orchestrator_version": "1.27.7"
   },
   "node_pools": {
     "apps1": {
@@ -13,7 +13,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.26.10"
+      "orchestrator_version": "1.27.7"
     }
   },
   "admin_group_id": "21b2f2a6-231e-45cb-b624-d5521b820941",


### PR DESCRIPTION
## Context
 https://trello.com/c/5FLQdnck/938-upgrade-clusters-to-kubernetes-1277

## Changes proposed in this pull request
 Test Cluster upgrade from 1.26.10 to 1.27.7

## Guidance to review
Updated cluster following steps provided https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/aks-upgrade.md 


## Before merging
<!-- Any extra steps like: delete temp commit, send warning, wait after office hours... -->

## After merging
<!-- Any extra steps like: update other PR, apply manually, inform someone... -->

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
