### PR TITLE
Create alermanager service

### DIFF
--- a/cluster/terraform_kubernetes/alertmanager.tf
+++ b/cluster/terraform_kubernetes/alertmanager.tf
@@ -1,0 +1,137 @@
+data "azurerm_key_vault_secret" "slack_secret" {
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  name         = "SLACK-SECRET"
+}
+resource "kubernetes_config_map" "alertmanager_config" {
+  metadata {
+    name      = "alertmanager-config"
+    namespace = kubernetes_namespace.default_list["monitoring"].metadata[0].name
+  }
+
+  data = {
+    "config.yml" = local.alertmanager_config_content
+  }
+}
+
+resource "kubernetes_config_map" "alertmanager_templates" {
+  metadata {
+    name      = "alertmanager-templates"
+    namespace = kubernetes_namespace.default_list["monitoring"].metadata[0].name
+  }
+
+  data = local.alertmanager_templates
+}
+
+resource "kubernetes_deployment" "alertmanager" {
+  metadata {
+    name      = "alertmanager"
+    namespace = kubernetes_namespace.default_list["monitoring"].metadata[0].name
+  }
+
+  spec {
+    replicas = 1
+    selector {
+      match_labels = {
+        app = "alertmanager"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "alertmanager"
+        }
+      }
+
+      spec {
+        container {
+          image = "prom/alertmanager:${var.alertmanager_image_version}"
+          name  = "alertmanager"
+
+          args = [
+            "--config.file=/etc/alertmanager/config.yml",
+            "--storage.path=/alertmanager",
+          ]
+
+
+          port {
+            container_port = 9093
+          }
+
+          resources {
+            limits = {
+              cpu    = 1
+              memory = var.alertmanager_app_mem
+            }
+
+            requests = {
+              cpu    = var.alertmanager_app_cpu
+              memory = var.alertmanager_app_mem
+            }
+          }
+
+          volume_mount {
+            mount_path = "/etc/alertmanager"
+            name       = "config-volume"
+          }
+
+          volume_mount {
+            mount_path = "/etc/alertmanager-templates"
+            name       = "templates-volume"
+          }
+
+          volume_mount {
+            mount_path = "/alertmanager"
+            name       = "alertmanager"
+          }
+        }
+
+        volume {
+          name = "config-volume"
+
+          config_map {
+            name = kubernetes_config_map.alertmanager_config.metadata[0].name
+          }
+        }
+
+        volume {
+          name = "templates-volume"
+
+          config_map {
+            name = kubernetes_config_map.alertmanager_templates.metadata[0].name
+          }
+        }
+
+        volume {
+          name = "alertmanager"
+          empty_dir {}
+        }
+      }
+    }
+  }
+}
+
+# Service for AlertManager
+resource "kubernetes_service" "alertmanager" {
+  metadata {
+    name      = "alertmanager"
+    namespace = kubernetes_namespace.default_list["monitoring"].metadata[0].name
+    annotations = {
+      "prometheus.io/port"   = "9093"
+      "prometheus.io/scrape" = "true"
+    }
+  }
+
+  spec {
+    selector = {
+      app = "alertmanager"
+    }
+
+    port {
+      port        = 9093
+      target_port = 9093
+    }
+
+    type = "NodePort"
+  }
+}

--- a/cluster/terraform_kubernetes/config/prometheus/alertmanager-config.yaml
+++ b/cluster/terraform_kubernetes/config/prometheus/alertmanager-config.yaml
@@ -1,0 +1,22 @@
+global:
+templates:
+  - '/etc/alertmanager/*.tmpl'
+route:
+  receiver: alert-default
+  group_by: ['alertname', 'priority']
+  group_wait: 10s
+  repeat_interval: 30m
+  routes:
+    - receiver: slack_demo
+      match:
+        severity: slack
+      group_wait: 10s
+      repeat_interval: 1m
+receivers:
+- name: alert-default
+- name: slack_demo
+  slack_configs:
+  - api_url: '${slack_secret}'
+    channel: '${slack_channel}'
+    send_resolved: true
+    text: '{{ template "slack.devops.text"  }}'

--- a/cluster/terraform_kubernetes/config/prometheus/alertmanager-slack.yaml
+++ b/cluster/terraform_kubernetes/config/prometheus/alertmanager-slack.yaml
@@ -1,0 +1,4 @@
+ {{ define "slack.devops.text" }}
+      {{range .Alerts}}{{.Annotations.DESCRIPTION}}
+      {{end}}
+{{ end }}

--- a/cluster/terraform_kubernetes/config/prometheus/development.prometheus.rules
+++ b/cluster/terraform_kubernetes/config/prometheus/development.prometheus.rules
@@ -4,12 +4,13 @@
 # Example rule below, which should be removed once real rules added
 #
 groups:
-- name: container restarts
+- name: High Number Of DesiredPods
   rules:
-  - alert: High number of restarted containers
-    expr: sum(kube_pod_container_status_restarts_total) > 1000
-    for: 5m
+  - alert: High Number Of DesiredPods
+    expr: kubelet_active_pods > 1000
+    for: 30m
     labels:
       severity: slack
     annotations:
-      summary: High number of restarted containers
+      description: High Number Of DesiredPods
+      summary: High Number Of DesiredPods

--- a/documentation/monitoring.md
+++ b/documentation/monitoring.md
@@ -79,3 +79,16 @@ limits - with cpu  of  300m and memory of 256Mi
 liveness_probe - with endpoint /healthz and port 8080
 readiness_probe - with endpoint / and port 8081
 telemetry - the telemetry data is accesses via port 8081
+
+## Alertmanager
+
+Alertmanager handles alerts sent by client applications such as the Prometheus server. It takes care of deduplicating, grouping, and routing them to the correct receiver integration such as email, Slack, or other notification mechanisms.
+
+Alertmanager service running on NodePort 9093 ,
+
+Alertmanager is single replica deployments.
+
+The default alert version is hardcoded in the kubernetes variable.tf. It can be overridden for a cluster by adding alertmanager_image_version to the env.tfvars.json file.
+There are several other variables that can be changed depending on env requirements.
+alertmanager_app_mem - app memory limit (default 1G)
+alertmanager_app_cpu - app cpu requests (default 1)

--- a/scripts/pfwd.sh
+++ b/scripts/pfwd.sh
@@ -6,6 +6,8 @@ PROM=`kubectl get pods -n monitoring -l app=prometheus --no-headers=true -o name
 # AMAN=`kubectl get pods -n monitoring -l app=alertmanager --no-headers=true -o name`
 GRAF=`kubectl get pods -n monitoring -l app=grafana --no-headers=true -o name`
 THANOS=`kubectl get service -n monitoring -l app=thanos-querier --no-headers=true -o name`
+
+ALERTMANAGER=`kubectl get pods -n monitoring -l app=alertmanager --no-headers=true -o name`
 echo $PROM
 # echo $AMAN
 # echo $GRAF
@@ -13,11 +15,14 @@ kubectl port-forward -n monitoring $PROM 8080:9090 &
 # kubectl port-forward -n monitoring $AMAN 8081:9093 &
 kubectl port-forward -n monitoring $GRAF 3000:3000 &
 kubectl port-forward -n monitoring $THANOS 8082:9090 &
+
+kubectl port-forward -n monitoring $ALERTMANAGER 8085:9093 &
 echo
 echo Prometheus at http://localhost:8080
 # echo Alertmanager at http://localhost:8081
 echo Grafana at http://localhost:3000
 echo Thanos at http://localhost:8082
+echo Alertmanager at http://localhost:8085
 echo
 echo kill with pkill kubectl
 echo


### PR DESCRIPTION
## Context
    Create alert manager service on monitoring namespace.
## Changes proposed in this pull request
     Create alertmanager
     Pull slack secret from azure key vault
## Guidance to review
    1 )  deploy  any one-off dev cluster  example : cluster4  , ENVIRONMENT=cluster4
    2 ) Do port-forward to check service is up and working kubectl -n monitoring port-forward service/alertmanager 8088:9093
    3 ) check http://localhost:8088 , alert manager UI should come.
 
## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
