### PR TITLE
Added Kube state metrics

### DIFF
--- a/cluster/terraform_kubernetes/config/prometheus/development.prometheus.yml
+++ b/cluster/terraform_kubernetes/config/prometheus/development.prometheus.yml
@@ -102,7 +102,7 @@ scrape_configs:
 # Scrape config for kube-state-metrics.
   - job_name: 'kube-state-metrics'
     static_configs:
-      - targets: ['kube-state-metrics.kube-system.svc.cluster.local:8080']
+      - targets: ['kube-state-metrics.monitoring.svc.cluster.local:8080']
 # Scrape config for Kubelet cAdvisor.
 #
 # This is required for Kubernetes 1.7.3 and later, where cAdvisor metrics

--- a/cluster/terraform_kubernetes/config/prometheus/platform-test.prometheus.yml
+++ b/cluster/terraform_kubernetes/config/prometheus/platform-test.prometheus.yml
@@ -102,7 +102,7 @@ scrape_configs:
 # Scrape config for kube-state-metrics.
   - job_name: 'kube-state-metrics'
     static_configs:
-      - targets: ['kube-state-metrics.kube-system.svc.cluster.local:8080']
+      - targets: ['kube-state-metrics.monitoring.svc.cluster.local:8080']
 # Scrape config for Kubelet cAdvisor.
 #
 # This is required for Kubernetes 1.7.3 and later, where cAdvisor metrics

--- a/cluster/terraform_kubernetes/config/prometheus/production.prometheus.yml
+++ b/cluster/terraform_kubernetes/config/prometheus/production.prometheus.yml
@@ -102,7 +102,7 @@ scrape_configs:
 # Scrape config for kube-state-metrics.
   - job_name: 'kube-state-metrics'
     static_configs:
-      - targets: ['kube-state-metrics.kube-system.svc.cluster.local:8080']
+      - targets: ['kube-state-metrics.monitoring.svc.cluster.local:8080']
 # Scrape config for Kubelet cAdvisor.
 #
 # This is required for Kubernetes 1.7.3 and later, where cAdvisor metrics

--- a/cluster/terraform_kubernetes/config/prometheus/test.prometheus.yml
+++ b/cluster/terraform_kubernetes/config/prometheus/test.prometheus.yml
@@ -102,7 +102,7 @@ scrape_configs:
 # Scrape config for kube-state-metrics.
   - job_name: 'kube-state-metrics'
     static_configs:
-      - targets: ['kube-state-metrics.kube-system.svc.cluster.local:8080']
+      - targets: ['kube-state-metrics.monitoring.svc.cluster.local:8080']
 # Scrape config for Kubelet cAdvisor.
 #
 # This is required for Kubernetes 1.7.3 and later, where cAdvisor metrics

--- a/cluster/terraform_kubernetes/kube_state_metrics.tf
+++ b/cluster/terraform_kubernetes/kube_state_metrics.tf
@@ -1,0 +1,167 @@
+
+
+resource "kubernetes_service_account" "kube_state_metrics" {
+  metadata {
+    name      = "kube-state-metrics"
+    namespace = kubernetes_namespace.default_list["monitoring"].metadata[0].name
+    labels = {
+      "app.kubernetes.io/component" = "exporter"
+      "app.kubernetes.io/name"      = "kube-state-metrics"
+      "app.kubernetes.io/version"   = var.kube_state_metrics_version
+    }
+  }
+}
+
+
+resource "kubernetes_cluster_role" "kube_state_metrics" {
+  metadata {
+    name = "kube-state-metrics"
+    labels = {
+      "app.kubernetes.io/component" = "exporter"
+      "app.kubernetes.io/name"      = "kube-state-metrics"
+      "app.kubernetes.io/version"   = var.kube_state_metrics_version
+    }
+  }
+  rule {
+    api_groups = ["", "apps", "batch", "networking.k8s.io", "policy", "autoscaling", "certificates.k8s.io", "coordination.k8s.io", "storage.k8s.io", "admissionregistration.k8s.io"]
+    resources  = ["pods", "replicasets", "cronjobs", "ingresses", "poddisruptionbudgets", "networkpolicies", "storageclasses", "certificatesigningrequests", "leases", "horizontalpodautoscalers", "configmaps", "secrets", "nodes", "services", "resourcequotas", "replicationcontrollers", "limitranges", "persistentvolumeclaims", "persistentvolumes", "namespaces", "endpoints", "deployments", "statefulsets", "daemonsets", "volumeattachments", "mutatingwebhookconfigurations", "validatingwebhookconfigurations", "jobs"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+}
+resource "kubernetes_cluster_role_binding" "kube_state_metrics" {
+  metadata {
+    name = "kube-state-metrics"
+    labels = {
+      "app.kubernetes.io/component" = "exporter"
+      "app.kubernetes.io/name"      = "kube-state-metrics"
+      "app.kubernetes.io/version"   = var.kube_state_metrics_version
+    }
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role.kube_state_metrics.metadata[0].name
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = "kube-state-metrics"
+    namespace = kubernetes_namespace.default_list["monitoring"].metadata[0].name
+  }
+}
+
+resource "kubernetes_deployment" "kube_state_metrics" {
+  metadata {
+    name      = "kube-state-metrics"
+    namespace = kubernetes_namespace.default_list["monitoring"].metadata[0].name
+    labels = {
+      "app.kubernetes.io/component" = "exporter"
+      "app.kubernetes.io/name"      = "kube-state-metrics"
+      "app.kubernetes.io/version"   = var.kube_state_metrics_version
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        "app.kubernetes.io/name" = "kube-state-metrics"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          "app.kubernetes.io/component" = "exporter"
+          "app.kubernetes.io/name"      = "kube-state-metrics"
+          "app.kubernetes.io/version"   = var.kube_state_metrics_version
+        }
+      }
+
+      spec {
+        automount_service_account_token = true
+        service_account_name            = kubernetes_service_account.kube_state_metrics.metadata[0].name
+
+        container {
+          name  = "kube-state-metrics"
+          image = "registry.k8s.io/kube-state-metrics/kube-state-metrics:v${var.kube_state_metrics_version}"
+          port {
+            name           = "http-metrics"
+            container_port = 8080
+          }
+          port {
+            name           = "telemetry"
+            container_port = 8081
+          }
+
+          # Add readiness/liveness probes, resources, etc
+          readiness_probe {
+            http_get {
+              path = "/"
+              port = 8081
+            }
+            initial_delay_seconds = 5
+            timeout_seconds       = 5
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/healthz"
+              port = 8080
+            }
+            initial_delay_seconds = 5
+          }
+          resources {
+            requests = {
+              cpu    = "100m"
+              memory = "128Mi"
+            }
+            limits = {
+              cpu    = "300m"
+              memory = "256Mi"
+            }
+          }
+        }
+        node_selector = {
+          "kubernetes.io/os" = "linux"
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "kube_state_metrics" {
+  metadata {
+    name      = "kube-state-metrics"
+    namespace = kubernetes_namespace.default_list["monitoring"].metadata[0].name
+
+    labels = {
+      "app.kubernetes.io/component" = "exporter"
+      "app.kubernetes.io/name"      = "kube-state-metrics"
+      "app.kubernetes.io/version"   = var.kube_state_metrics_version
+    }
+  }
+
+  spec {
+    cluster_ip = "None"
+
+    selector = {
+      "app.kubernetes.io/name" = "kube-state-metrics"
+    }
+
+    port {
+      name        = "http-metrics"
+      port        = 8080
+      target_port = "http-metrics"
+    }
+
+    port {
+      name        = "telemetry"
+      port        = 8081
+      target_port = "telemetry"
+    }
+  }
+}

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -80,6 +80,10 @@ variable "lowpriority_app_replicas" {
   default = 3
 }
 
+variable "kube_state_metrics_version" {
+  default = "2.10.1"
+}
+
 data "azurerm_client_config" "current" {}
 
 data "environment_variables" "github_actions" {
@@ -197,4 +201,5 @@ locals {
     var.cluster_short : # pt,ts or pd
     var.environment     # cluster1, cluster2, etc
   )
+
 }

--- a/documentation/monitoring.md
+++ b/documentation/monitoring.md
@@ -67,3 +67,14 @@ The default grafana version is hardcoded in the kubernetes variable.tf. It can b
 There are several other variables that can be changed depending on env requirements. e.g.
 grafana_app_mem - app memory limit (default 1Gi)
 grafana_app_cpu - app requests cpu (default 500m)
+
+## kube state metrics
+Kube-state-metrics is a listening service that generates metrics about the state of Kubernetes objects through leveraging the Kubernetes API; it focuses on object health instead of component health
+
+The default Kube-state-metrics version is hardcoded to version v2.8.2 by adding kube_state_metrics_version to variables.tf
+The metrics scraped are:
+requests -  with  cpu   of  100m and memory of 128Mi
+limits - with cpu  of  300m and memory of 256Mi
+liveness_probe - with endpoint /healthz and port 8080
+readiness_probe - with endpoint / and port 8081
+telemetry - the telemetry data is accesses via port 8081


### PR DESCRIPTION
Trello Card:
https://trello.com/c/NHmSbfNc/929-configure-kube-state-metrics

## Context
Added Kube state metrics which is an important component of monitoring

## Changes proposed in this pull request
added the terraform resources that will provision kube state metrics

## Guidance to review
make development terraform-kubernetes-apply  ENVIRONMENT=cluster3       
kubectl port-forward -n kube-system service/kube-state-metrics 8080:8080
curl localhost:8080/metrics

kubectl port-forward -n kube-system service/kube-state-metrics 8081:8081
curl localhost:8081/telemetry



