### PR TITLE
Increase test/prod thanos-compactor memory to 2G

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -35,5 +35,6 @@
   "prometheus_app_cpu": "0.5",
   "thanos_app_mem": "1Gi",
   "thanos_app_cpu": "0.5",
+  "thanos_compactor_app_mem": "2Gi",
   "cluster_short": "pd"
 }

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -39,6 +39,7 @@
   "prometheus_app_mem": "2Gi",
   "prometheus_app_cpu": "0.5",
   "thanos_app_mem": "1Gi",
+  "thanos_compactor_app_mem": "2Gi",
   "thanos_app_cpu": "0.5",
   "cluster_short": "ts"
 }

--- a/cluster/terraform_kubernetes/thanos.tf
+++ b/cluster/terraform_kubernetes/thanos.tf
@@ -307,11 +307,11 @@ resource "kubernetes_deployment" "thanos-compactor" {
           resources {
             limits = {
               cpu    = 1
-              memory = var.thanos_app_mem
+              memory = var.thanos_compactor_app_mem
             }
             requests = {
               cpu    = var.thanos_app_cpu
-              memory = var.thanos_app_mem
+              memory = var.thanos_compactor_app_mem
             }
           }
 

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -118,6 +118,11 @@ variable "thanos_app_mem" {
   default     = "1Gi"
 }
 
+variable "thanos_compactor_app_mem" {
+  description = "Thanos compactor memory limit"
+  default     = "1Gi"
+}
+
 variable "thanos_app_cpu" {
   description = "Thanos app cpu request"
   default     = "100m"

--- a/documentation/monitoring.md
+++ b/documentation/monitoring.md
@@ -52,6 +52,7 @@ The default thanos version is hardcoded in the kubernetes variable.tf. It can be
 There are several other variables that can be changed depending on env requirements.
 thanos_app_mem - app memory limit (default 1G)
 thanos_app_cpu - app memory requests (default 100m)
+thanos_compactor_app_mem - app memory limit for the thanos compactor (default 1G)
 thanos_retention_raw - Thanos retention period for raw samples (default 30d)
 thanos_retention_5m - Thanos retention period for 5m samples (default 60d)
 thanos_retention_1h - Thanos retention period for 1h samples (default 90d)


### PR DESCRIPTION
## Context
https://trello.com/c/IbAu4gQD/1648-investigate-thanos-compactor-failure

Thanos compactor running out of memory on test and production clusters

## Changes proposed in this pull request
Increase compactor memory to 2G

## Guidance to review

make test terraform-plan (no change as manually applied to test cluster)
make production terraform-plan

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
