### PR TITLE
Added ingress controller scraping

### DIFF
--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -106,6 +106,25 @@ resource "helm_release" "ingress-nginx" {
     type  = "string"
   }
 
+  # Annotations to enable scraping for ingress controller
+  # where podAnnotations is the top level property, port is ingress controller port for metrics,
+  # path is default path for metrics used throughout, enabled is true if scraping is desired
+  set {
+    name  = "controller.podAnnotations.prometheus\\.io/scrape"
+    value = "true"
+    type  = "string"
+  }
+  set {
+    name  = "controller.podAnnotations.prometheus\\.io/path"
+    value = "/metrics"
+    type  = "string"
+  }
+  set {
+    name  = "controller.podAnnotations.prometheus\\.io/port"
+    value = "10254"
+    type  = "string"
+  }
+
 }
 
 resource "helm_release" "ingress-nginx-clone" {


### PR DESCRIPTION

## Trello card
https://trello.com/c/QZ7J2MX8/934-add-custom-metric-scraping

## Context
<!-- Why are we making this change? New feature? Bug fix? -->

## Changes proposed in this pull request
added ingress controller scraping by setting the podannotations

## Guidance to review
port forward the ingress controller pod and the prometheus pod
access the cluster 3 welcome page at https://www.cluster3.development.teacherservices.cloud/
notice the changes in the metrics shown eg 
promhttp_metric_handler_requests_total{code="200"} 34
nginx_ingress_controller_nginx_process_requests_total 
etc

