### PR TITLE
Allow sending app logs to logit using filebeat

### DIFF
--- a/cluster/terraform_kubernetes/config/filebeat/filebeat.yml.tmpl
+++ b/cluster/terraform_kubernetes/config/filebeat/filebeat.yml.tmpl
@@ -1,0 +1,20 @@
+filebeat.autodiscover:
+  providers:
+      - type: kubernetes
+        templates:
+          - condition:
+              equals:
+                kubernetes.annotations.logit.io/send: "true"
+            config:
+              - type: container
+                paths:
+                  - "/var/log/containers/*-$${data.kubernetes.container.id}.log"
+        add_resource_metadata:
+          node:
+            enabled: false
+          deployment: true
+
+output.logstash:
+  hosts: ["${BEATS_URL}"]
+  loadbalance: true
+  ssl.enabled: true

--- a/cluster/terraform_kubernetes/filebeat.tf
+++ b/cluster/terraform_kubernetes/filebeat.tf
@@ -1,0 +1,176 @@
+data "azurerm_key_vault_secret" "beats_url" {
+  name         = "BEATS-URL"
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+}
+
+resource "kubernetes_service_account" "filebeat" {
+  metadata {
+    name      = "filebeat"
+    namespace = kubernetes_namespace.default_list["monitoring"].metadata[0].name
+    labels = {
+      "name" = "filebeat"
+    }
+  }
+}
+
+
+resource "kubernetes_cluster_role" "filebeat" {
+  metadata {
+    name = "filebeat"
+    labels = {
+      "name" = "filebeat"
+    }
+  }
+  rule {
+    api_groups = [""]
+    resources  = ["pods", "nodes", "namespaces"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["apps"]
+    resources  = ["replicasets"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+}
+resource "kubernetes_cluster_role_binding" "filebeat" {
+  metadata {
+    name = "filebeat"
+    labels = {
+      "name" = "filebeat"
+    }
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role.filebeat.metadata[0].name
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = "filebeat"
+    namespace = kubernetes_namespace.default_list["monitoring"].metadata[0].name
+  }
+}
+
+resource "kubernetes_config_map" "filebeat" {
+
+  metadata {
+    name      = "filebeat-config"
+    namespace = kubernetes_namespace.default_list["monitoring"].metadata[0].name
+  }
+
+  data = {
+    "filebeat.yml" = templatefile("${path.module}/config/filebeat/filebeat.yml.tmpl", local.filebeats_template_variable_map)
+  }
+
+}
+
+resource "kubernetes_daemonset" "filebeat" {
+
+  metadata {
+    name      = "filebeat"
+    namespace = kubernetes_namespace.default_list["monitoring"].metadata[0].name
+    labels = {
+      app = "filebeat"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels = {
+        app = "filebeat"
+      }
+    }
+
+
+    template {
+      metadata {
+        labels = {
+          app = "filebeat"
+        }
+      }
+
+      spec {
+        service_account_name             = kubernetes_service_account.filebeat.metadata[0].name
+        termination_grace_period_seconds = 30
+
+        node_selector = {
+          "teacherservices.cloud/node_pool" = "applications"
+          "kubernetes.io/os"                = "linux"
+        }
+
+        container {
+          image = "docker.elastic.co/beats/filebeat-oss:${var.filebeat_version}"
+          name  = "filebeat"
+
+          args = [
+            "-c",
+            "filebeat.yml",
+            "-e",
+          ]
+
+          security_context {
+            run_as_user = 0
+          }
+
+          resources {
+            limits = {
+              cpu    = "200m"
+              memory = "200Mi"
+            }
+            requests = {
+              cpu    = "100m"
+              memory = "100Mi"
+            }
+          }
+
+          volume_mount {
+            mount_path = "/usr/share/filebeat/filebeat.yml"
+            name       = "filebeat-config"
+            read_only  = "true"
+            sub_path   = "filebeat.yml"
+          }
+
+          volume_mount {
+            mount_path = "/usr/share/filebeat/data"
+            name       = "data"
+          }
+
+          volume_mount {
+            mount_path = "/var/log"
+            name       = "varlog"
+            read_only  = "true"
+          }
+
+        }
+
+        volume {
+          name = "filebeat-config"
+          config_map {
+            name         = "filebeat-config"
+            default_mode = "0644"
+          }
+        }
+
+        volume {
+          name = "varlog"
+          host_path {
+            path = "/var/log"
+          }
+        }
+
+        volume {
+          name = "data"
+          host_path {
+            path = "/var/lib/filebeat-data"
+            type = "DirectoryOrCreate"
+          }
+        }
+
+      }
+    }
+  }
+}

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -175,6 +175,9 @@ variable "alertmanager_app_mem" {
 variable "node_exporter_version" {
   default = "v1.7.0"
 }
+variable "filebeat_version" {
+  default = "8.12.2"
+}
 
 locals {
   cluster_name = (
@@ -229,6 +232,10 @@ locals {
   template_variable_map = {
     storage-account-name = azurerm_storage_account.thanos.name
     storage-account-key  = azurerm_storage_account.thanos.primary_access_key
+  }
+
+  filebeats_template_variable_map = {
+    BEATS_URL = data.azurerm_key_vault_secret.beats_url.value
   }
 
   cluster_sa_name = (var.environment == var.config ?

--- a/documentation/aks-logs.md
+++ b/documentation/aks-logs.md
@@ -46,3 +46,12 @@ Here are some examples of KQL queries that you can use to retrieve AKS Log Analy
     ```
 
 These are just a few examples of the many queries that you can write using KQL to retrieve AKS Log Analytics data.
+
+# Logit.io logging
+
+Pod log forwarding to logit.io has been enabled within each cluster.
+
+Filebeat runs in each node, and monitors for pods with the annotation "logit.io/send: true".
+Once identified, logs will be sent to the cluster BEATS_URL which is contained in the cluster KV.
+
+Services that use terraform-modules can enable logit.io logging by adding "enable_logit: true" to app environments.


### PR DESCRIPTION
## Context
Enable filebeat to send logs to logit.io
It will send logs to logit if the container has annotation logit.io/send: true

## Changes proposed in this pull request
Terraform updates

## Guidance to review
Deployed to cluster5, with app container sending logs to logit.io
make development terraform-plan ENVIRONMENT=cluster5

App deployed using terraform-modules branch 906-spike-application-log-shipping

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
