### PR TITLE
Increase prometheus and thanos memory settings

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -31,10 +31,11 @@
   ],
   "ingress_nginx_version": "4.8.3",
   "enable_lowpriority_app": true,
-  "prometheus_app_mem": "4Gi",
+  "prometheus_app_mem": "6Gi",
   "prometheus_app_cpu": "0.5",
-  "thanos_app_mem": "1Gi",
+  "thanos_querier_mem": "2Gi",
   "thanos_app_cpu": "0.5",
-  "thanos_compactor_app_mem": "2Gi",
+  "thanos_compactor_mem": "3Gi",
+  "thanos_store_mem": "2Gi",
   "cluster_short": "pd"
 }

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -36,10 +36,11 @@
   "enable_lowpriority_app": true,
   "lowpriority_app_cpu": "0.5",
   "lowpriority_app_mem": "1Gi",
-  "prometheus_app_mem": "4Gi",
+  "prometheus_app_mem": "6Gi",
   "prometheus_app_cpu": "0.5",
-  "thanos_app_mem": "1Gi",
-  "thanos_compactor_app_mem": "2Gi",
+  "thanos_querier_mem": "2Gi",
+  "thanos_store_mem": "2Gi",
+  "thanos_compactor_mem": "3Gi",
   "thanos_app_cpu": "0.5",
   "cluster_short": "ts"
 }

--- a/cluster/terraform_kubernetes/prometheus.tf
+++ b/cluster/terraform_kubernetes/prometheus.tf
@@ -176,11 +176,11 @@ resource "kubernetes_deployment" "prometheus" {
           resources {
             limits = {
               cpu    = 1
-              memory = var.prometheus_app_mem
+              memory = var.thanos_app_mem
             }
             requests = {
-              cpu    = var.prometheus_app_cpu
-              memory = var.prometheus_app_mem
+              cpu    = var.thanos_app_cpu
+              memory = var.thanos_app_mem
             }
           }
 

--- a/cluster/terraform_kubernetes/thanos.tf
+++ b/cluster/terraform_kubernetes/thanos.tf
@@ -115,11 +115,11 @@ resource "kubernetes_deployment" "thanos-querier" {
           resources {
             limits = {
               cpu    = 1
-              memory = var.thanos_app_mem
+              memory = var.thanos_querier_mem
             }
             requests = {
               cpu    = var.thanos_app_cpu
-              memory = var.thanos_app_mem
+              memory = var.thanos_querier_mem
             }
           }
         }
@@ -218,11 +218,11 @@ resource "kubernetes_deployment" "thanos-store-gateway" {
           resources {
             limits = {
               cpu    = 1
-              memory = var.thanos_app_mem
+              memory = var.thanos_store_mem
             }
             requests = {
               cpu    = var.thanos_app_cpu
-              memory = var.thanos_app_mem
+              memory = var.thanos_store_mem
             }
           }
 
@@ -307,11 +307,11 @@ resource "kubernetes_deployment" "thanos-compactor" {
           resources {
             limits = {
               cpu    = 1
-              memory = var.thanos_compactor_app_mem
+              memory = var.thanos_compactor_mem
             }
             requests = {
               cpu    = var.thanos_app_cpu
-              memory = var.thanos_compactor_app_mem
+              memory = var.thanos_compactor_mem
             }
           }
 

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -114,12 +114,22 @@ variable "thanos_version" {
 }
 
 variable "thanos_app_mem" {
-  description = "Thanos app memory limit"
+  description = "Thanos sidecar memory limit"
   default     = "1Gi"
 }
 
-variable "thanos_compactor_app_mem" {
+variable "thanos_querier_mem" {
+  description = "Thanos querier memory limit"
+  default     = "1Gi"
+}
+
+variable "thanos_compactor_mem" {
   description = "Thanos compactor memory limit"
+  default     = "1Gi"
+}
+
+variable "thanos_store_mem" {
+  description = "Thanos store gateway memory limit"
   default     = "1Gi"
 }
 

--- a/documentation/monitoring.md
+++ b/documentation/monitoring.md
@@ -54,9 +54,11 @@ All are running as single replica deployments.
 The default thanos version is hardcoded in the kubernetes variables.tf. It can be overridden for a cluster by adding thanos_version to the env.tfvars.json file.
 
 There are several other variables that can be changed depending on env requirements.
-- thanos_app_mem - app memory limit (default 1G)
-- thanos_app_cpu - app memory requests (default 100m)
-- thanos_compactor_app_mem - app memory limit for the thanos compactor (default 1G)
+- thanos_app_mem - sidecar memory limit (default 1G)
+- thanos_app_cpu - thanos cpu requests (default 100m)
+- thanos_querier_mem - app memory limit for the thanos querier (default 1G)
+- thanos_compactor_mem - app memory limit for the thanos compactor (default 1G)
+- thanos_store_mem - app memory limit for the thanos store gateway (default 1G)
 - thanos_retention_raw - Thanos retention period for raw samples (default 30d)
 - thanos_retention_5m - Thanos retention period for 5m samples (default 60d)
 - thanos_retention_1h - Thanos retention period for 1h samples (default 90d)


### PR DESCRIPTION
## Context
Prometheus and thanos pods failing due to insufficient memory in test and prod clusters

## Changes proposed in this pull request
Separate memory variables and Increase memory limits
Manually applied to pods to confirm they stop failures

## Guidance to review
make test terraform-plan

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
