### PR TITLE
Prometheus memory increased to fix CrashLoop

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -31,7 +31,7 @@
   ],
   "ingress_nginx_version": "4.8.3",
   "enable_lowpriority_app": true,
-  "prometheus_app_mem": "6Gi",
+  "prometheus_app_mem": "8Gi",
   "prometheus_app_cpu": "0.5",
   "thanos_querier_mem": "2Gi",
   "thanos_app_cpu": "0.5",


### PR DESCRIPTION
## Context
Production prometheus pod is crashlooping with Out of memeory

## Changes proposed in this pull request
Bumped prometheus memory  to 8GB

## Guidance to review
Connect prod cluster and verify prometheus pod status  using command :  kubectl -n monitoring get po -l app=prometheus
the status should be Running.

 
## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
