### PR TITLE
Added Ingress and basic auth for prometheus,alertmanager and thanos

### DIFF
--- a/documentation/monitoring.md
+++ b/documentation/monitoring.md
@@ -110,3 +110,12 @@ It's deployed as a daemon set, which creates a node-exporter pod in each node on
 Prometheus then scrapes port 9100 on each of these pods.
 
 The default node exporter version is hardcoded in the kubernetes variables.tf. It can be overridden for a cluster by adding node_exporter_version to the env.tfvars.json file.
+
+### PROMETHEUS , ALERTMANAGER and THANOS Auth Key generation.
+
+For auth key generation run the shell script 'scripts/hash_password.sh' by passing username and password , then take the generated key save in to azure vault as a secret.
+
+Following auth keys need to be stored on azure vault as a secret.
+1. PROMETHEUS-AUTH
+2. ALERTMANAGER-AUTH
+3. THANOS-AUTH

--- a/scripts/hash_password.sh
+++ b/scripts/hash_password.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# hash_password.sh
+username=$1
+password=$2
+
+set -eu
+
+if [ -z "$username" ] || [ -z "$password" ]; then
+    echo "Error: Both username and password are mandatory."
+    exit 1
+fi
+# Ensure the password is hashed correctly and output is formatted as expected
+hashed_password=$(htpasswd -nbB "$username" "$password")
+echo "{\"hashed_password\":\"$hashed_password\"}"


### PR DESCRIPTION
## Context
Add ingress for prometheus , alertmanager and thanos with basic auth.

## Changes proposed in this pull request
 1 . Added ingress for prometheus, alertmanager and thanos.
 2 . Added basic auth with user and password pull from vault.

## Guidance to review
1 ) Deploy the changes in development  cluster  using command like :  make development terraform-apply  ENVIRONMENT=cluster4
2 ) Access enpoints using authentication.
    Example
         https://thanos.cluster4.development.teacherservices.cloud/
         https://alertmanager.cluster4.development.teacherservices.cloud/
         https://prometheus.cluster4.development.teacherservices.cloud/

 
## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
