### PR TITLE
Spike sidecar reload of prometheus on yml update

### DIFF
--- a/cluster/terraform_kubernetes/scripts/config-reloader.sh
+++ b/cluster/terraform_kubernetes/scripts/config-reloader.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Monitor a config file for updates and reload the service if it has changed
+#
+
+###
+### Main
+###
+
+sleep 60
+
+touch /tmp/last-reload
+
+while true; do
+    find -H /etc/prometheus/prometheus.yml -newer /tmp/last-reload -exec wget -O- --post-data '' http://127.0.0.1:9090/-/reload \;
+    find -H /etc/prometheus/prometheus.yml -newer /tmp/last-reload -exec touch /tmp/last-reload \;
+    sleep 60
+    done


### PR DESCRIPTION
## Context
Test using a sidecar to restart prometheus when the config file is updated

## Changes proposed in this pull request
Add config-reloader sidecar to prometheus
Add quick config-reloader.sh script to monitor for config file changes 

## Guidance to review
Deploy to a dev cluster
make an update to prometheus.yml and confirm prometheus reloads 

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
