### PR TITLE
Feature/1662 add all pod alert rules

### DIFF
--- a/cluster/terraform_kubernetes/config/prometheus/alertmanager/app_alert.rules.tmpl
+++ b/cluster/terraform_kubernetes/config/prometheus/alertmanager/app_alert.rules.tmpl
@@ -1,13 +1,20 @@
 groups:
 - name: Container restarts
   rules:
-  - alert: High number of restarted containers
-    expr: sum(kube_pod_container_status_restarts_total) > 1000
+%{ for instance in apps ~}
+  - alert: High number of restarted containers for ${instance.app_name}
+    expr: sum(rate(kube_pod_container_status_restarts_total{container!="",namespace="development",pod=~"apply-review-nnnn-[a-z0-9]+-[a-z0-9]+"  }[5m]) * 300  ) by (namespace,container) > ${instance.max_crash_count}
     for: 5m
+    annotations:
+      summary: High number of restarted containers for ${instance.app_name}
+      description: "The rate of container restart has been above ${instance.max_crash_count}  in the last 5 minutes (current value: {{ $value }})"
     labels:
       severity: high
-    annotations:
-      summary: High number of restarted containers
+      app: ${instance.app_name}
+      %{ if instance.receiver != null }receiver: ${instance.receiver}%{ endif }
+
+%{ endfor ~}
+
 - name: High CPU
   rules:
 %{ for instance in apps ~}
@@ -22,3 +29,19 @@ groups:
       app: ${instance.app_name}
       %{ if instance.receiver != null }receiver: ${instance.receiver}%{ endif }
 %{ endfor ~}
+
+- name: Memory Utilisation
+  rules:
+%{ for instance in apps ~}
+  - alert: High Memory Utilisation for ${instance.app_name}
+    expr: sum by (namespace, container) (container_memory_working_set_bytes{container!="",image!="",namespace="development",pod=~"apply-review-nnnn-[a-z0-9]+-[a-z0-9]+"})/sum by (namespace, container) (kube_pod_container_resource_requests{container!="",namespace="development",pod=~"apply-review-nnnn-[a-z0-9]+-[a-z0-9]+",resource="memory"}) > ${instance.max_mem}
+    for: 5m
+    annotations:
+      summary:     ${instance.app_name} high memory utilization
+      description: "Memory utilization has increased in the last 5 minutes (current value: {{ $value | humanizePercentage }})"
+    labels:
+      severity:    high
+      app:         ${instance.app_name}
+      %{ if instance.receiver != null }receiver: ${instance.receiver}%{ endif }
+%{ endfor ~}
+

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -258,15 +258,12 @@ locals {
 
   app_alert_rules_variables = {
     apps = [for instance, settings in var.alertable_apps : {
-      namespace                      = split("/", instance)[0]
-      app_name                       = split("/", instance)[1]
-      max_cpu                        = try(settings.max_cpu, 0.6)
-      max_mem                        = try(settings.max_mem, 60)
-      max_disk                       = try(settings.max_disk, 60)
-      max_crash_count                = try(settings.max_crash_count, 1)
-      max_elevated_req_failure_count = try(settings.max_elevated_req_failure_count, 0.1)
-      response_threshold             = try(settings.response_threshold, 1)
-      receiver                       = try(settings.receiver, "SLACK_WEBHOOK_GENERIC")
+      namespace       = split("/", instance)[0]
+      app_name        = split("/", instance)[1]
+      max_cpu         = try(settings.max_cpu, 0.6)
+      max_mem         = try(settings.max_mem, 0.6)
+      max_crash_count = try(settings.max_crash_count, 1)
+      receiver        = try(settings.receiver, "SLACK_WEBHOOK_GENERIC")
       }
     ]
   }


### PR DESCRIPTION
## Trello card
https://trello.com/c/z59gFKWD/1662-add-all-pod-alert-rules

## Context
in order to add more alert rules  including high memory and high number of restarts

## Changes proposed in this pull request
added alerts rules for high memory and high number of restarts

## Guidance to review
use stress-ng to trigger high memory usage and use kill to trigger container restart of pod
