### PR TITLE
 Number of nodes increased for dev node_pool

### DIFF
--- a/cluster/terraform_aks_cluster/config/development.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/development.tfvars.json
@@ -8,7 +8,7 @@
   "node_pools": {
     "apps1": {
       "min_count": 1,
-      "max_count": 3,
+      "max_count": 4,
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },


### PR DESCRIPTION
## Context
 Number of nodes increased from 3 to 4 for dev cluster.
## Changes proposed in this pull request
 node_pools.app1 max_count set to 4

## Guidance to review
Login to azure console and go to AKS cluster , verify node pool apps1 max should be 4.

 

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
