### PR TITLE
Added monitoring for GIT App and GIT API

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -45,8 +45,8 @@
     "SLACK_WEBHOOK_TRS",
     "SLACK_WEBHOOK_TV",
     "SLACK_WEBHOOK_CCBL",
-    "SLACK_WEBHOOK_FALTRN"
-
+    "SLACK_WEBHOOK_FALTRN",
+    "SLACK_WEBHOOK_GIT"
   ],
   "alertable_apps": {
     "bat-production/apply-production": {
@@ -58,13 +58,13 @@
        "max_cpu": 0.8
     },
     "bat-production/register-production": {
-      "receiver":"SLACK_WEBHOOK_RTT",
-      "max_cpu": 0.8
-   },
-   "bat-production/register-sandbox": {
-      "receiver":"SLACK_WEBHOOK_RTT",
-      "max_cpu": 0.8
-   },
+       "receiver":"SLACK_WEBHOOK_RTT",
+       "max_cpu": 0.8
+    },
+    "bat-production/register-sandbox": {
+       "receiver":"SLACK_WEBHOOK_RTT",
+       "max_cpu": 0.8
+    },
     "git-production/get-school-experience-production": {
        "receiver":"SLACK_WEBHOOK_GSE"
     },
@@ -81,22 +81,28 @@
        "receiver":"SLACK_WEBHOOK_TRS"
     },
     "tv-production/teaching-vacancies-production": {
-     "receiver": "SLACK_WEBHOOK_TV",
-     "max_cpu": 0.8
-   },
-   "tv-production/teaching-vacancies-production-worker": {
-     "receiver": "SLACK_WEBHOOK_TV",
-     "max_cpu": 0.8
-   },
-   "tra-production/check-childrens-barred-list-production": {
-      "receiver":"SLACK_WEBHOOK_CCBL"
-   },
-   "tra-production/check-childrens-barred-list-production-worker": {
-      "receiver":"SLACK_WEBHOOK_CCBL"
-   },
-   "tra-production/find-a-lost-trn-production": {
-    "receiver":"SLACK_WEBHOOK_FALTRN",
-    "max_cpu": 0.8
-  }
+       "receiver": "SLACK_WEBHOOK_TV",
+       "max_cpu": 0.8
+    },
+    "tv-production/teaching-vacancies-production-worker": {
+       "receiver": "SLACK_WEBHOOK_TV",
+       "max_cpu": 0.8
+    },
+    "tra-production/check-childrens-barred-list-production": {
+       "receiver":"SLACK_WEBHOOK_CCBL"
+    },
+    "tra-production/check-childrens-barred-list-production-worker": {
+       "receiver":"SLACK_WEBHOOK_CCBL"
+    },
+    "tra-production/find-a-lost-trn-production": {
+      "receiver":"SLACK_WEBHOOK_FALTRN",
+      "max_cpu": 0.8
+    },
+    "git-production/get-into-teaching-app-production": {
+       "receiver":"SLACK_WEBHOOK_GIT"
+    },
+    "git-production/getintoteachingapi-production": {
+       "receiver":"SLACK_WEBHOOK_GIT"
+    }
   }
 }

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -52,20 +52,25 @@
       "receiver": "SLACK_WEBHOOK_ATT",
       "max_cpu": 0.8
     },
-
     "bat-staging/register-staging": {
       "receiver": "SLACK_WEBHOOK_RTT",
       "max_cpu": 0.8
     },
-
     "git-test/get-school-experience-staging": {
-       "receiver":"SLACK_WEBHOOK_GSE"
+      "receiver":"SLACK_WEBHOOK_GSE"
+    },
+    "git-test/get-into-teaching-app-test": {
+      "receiver":"SLACK_WEBHOOK_GIT"
+    } ,
+    "git-test/getintoteachingapi-test": {
+      "receiver":"SLACK_WEBHOOK_GIT"
     }
   },
   "alertmanager_slack_receiver_list": [
     "SLACK_WEBHOOK_ATT",
     "SLACK_WEBHOOK_RTT",
-    "SLACK_WEBHOOK_GSE"
+    "SLACK_WEBHOOK_GSE",
+    "SLACK_WEBHOOK_GIT"
   ]
 }
 


### PR DESCRIPTION
## Trello
https://trello.com/c/rO6NTNwx/1700-create-alerts-for-all-services

## Context
Added monitoring for GIT App and GIT API

## Changes proposed in this pull request
added GIT App and GIT API to the list of alertable apps in config

## Guidance to review
make test terraform-kubernetes-plan CONFIRM_TEST=yes
