### PR TITLE
1700 create alerts for all services  Teaching vacancies  and  Check the children’s barred list

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -41,7 +41,11 @@
   "alertmanager_slack_receiver_list": [
     "SLACK_WEBHOOK_ATT",
     "SLACK_WEBHOOK_RTT",
-    "SLACK_WEBHOOK_GSE"
+    "SLACK_WEBHOOK_GSE",
+    "SLACK_WEBHOOK_TRS",
+    "SLACK_WEBHOOK_TV",
+    "SLACK_WEBHOOK_CCBL"
+
   ],
   "alertable_apps": {
     "bat-production/apply-production": {
@@ -51,7 +55,7 @@
     "bat-production/apply-sandbox": {
        "receiver":"SLACK_WEBHOOK_ATT",
        "max_cpu": 0.8
-    },  
+    },
     "bat-production/register-production": {
       "receiver":"SLACK_WEBHOOK_RTT",
       "max_cpu": 0.8
@@ -62,14 +66,32 @@
    },
     "git-production/get-school-experience-production": {
        "receiver":"SLACK_WEBHOOK_GSE"
-    }
+    },
+    "tra-production/trs-production-api": {
+       "receiver":"SLACK_WEBHOOK_TRS"
+    },
+    "tra-production/trs-production-authz": {
+       "receiver":"SLACK_WEBHOOK_TRS"
+    },
+    "tra-production/trs-production-ui": {
+       "receiver":"SLACK_WEBHOOK_TRS"
+    },
+    "tra-production/trs-production-worker": {
+       "receiver":"SLACK_WEBHOOK_TRS"
+    },
+    "tv-production/teaching-vacancies-production": {
+     "receiver": "SLACK_WEBHOOK_TV",
+     "max_cpu": 0.8
+   },
+   "tv-production/teaching-vacancies-production-worker": {
+     "receiver": "SLACK_WEBHOOK_TV",
+     "max_cpu": 0.8
+   },
+   "tra-production/check-childrens-barred-list-production": {
+      "receiver":"SLACK_WEBHOOK_CCBL"
+   },
+   "tra-production/check-childrens-barred-list-production-worker": {
+      "receiver":"SLACK_WEBHOOK_CCBL"
+   }
   }
 }
-
-
-
-
-
-
-
-


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
Alerts for Teacher Qualifications API, Teaching vacancies  and  Check the children’s barred list

## Changes proposed in this pull request
<!-- Describe briefly the technical implementation -->
<!-- Show any dependencies between pull requests, i.e. this must be merged before or after another -->

## Guidance to review

Terraform plan :

 `                   app:         get-school-experience-production
                      receiver: SLACK_WEBHOOK_GSE
              +   - alert: High Memory Utilisation for check-childrens-barred-list-production
              +     expr: sum by (namespace, container) (container_memory_working_set_bytes{container!="",image!="",namespace="tra-production",pod=~"check-childrens-barred-list-production-[a-z0-9]+-[a-z0-9]+"})/sum by (namespace, container) (kube_pod_container_resource_limits{container!="",namespace="tra-production",pod=~"check-childrens-barred-list-production-[a-z0-9]+-[a-z0-9]+",resource="memory"}) > 0.6
              +     for: 5m
              +     annotations:
              +       summary:     check-childrens-barred-list-production high memory utilization
              +       description: "Memory utilization has increased in the last 5 minutes (current value: {{ $value | humanizePercentage }})"
              +     labels:
              +       severity:    high
              +       app:         check-childrens-barred-list-production
              +       receiver: SLACK_WEBHOOK_CCBL
              +   - alert: High Memory Utilisation for check-childrens-barred-list-production-worker
              +     expr: sum by (namespace, container) (container_memory_working_set_bytes{container!="",image!="",namespace="tra-production",pod=~"check-childrens-barred-list-production-worker-[a-z0-9]+-[a-z0-9]+"})/sum by (namespace, container) (kube_pod_container_resource_limits{container!="",namespace="tra-production",pod=~"check-childrens-barred-list-production-worker-[a-z0-9]+-[a-z0-9]+",resource="memory"}) > 0.6
              +     for: 5m
              +     annotations:
              +       summary:     check-childrens-barred-list-production-worker high memory utilization
              +       description: "Memory utilization has increased in the last 5 minutes (current value: {{ $value | humanizePercentage }})"
              +     labels:
              +       severity:    high
              +       app:         check-childrens-barred-list-production-worker
              +       receiver: SLACK_WEBHOOK_CCBL
              +   - alert: High Memory Utilisation for trs-production-api
              +     expr: sum by (namespace, container) (container_memory_working_set_bytes{container!="",image!="",namespace="tra-production",pod=~"trs-production-api-[a-z0-9]+-[a-z0-9]+"})/sum by (namespace, container) (kube_pod_container_resource_limits{container!="",namespace="tra-production",pod=~"trs-production-api-[a-z0-9]+-[a-z0-9]+",resource="memory"}) > 0.6
              +     for: 5m
              +     annotations:
              +       summary:     trs-production-api high memory utilization
              +       description: "Memory utilization has increased in the last 5 minutes (current value: {{ $value | humanizePercentage }})"
              +     labels:
              +       severity:    high
              +       app:         trs-production-api
              +       receiver: SLACK_WEBHOOK_TRS
              +   - alert: High Memory Utilisation for trs-production-authz
              +     expr: sum by (namespace, container) (container_memory_working_set_bytes{container!="",image!="",namespace="tra-production",pod=~"trs-production-authz-[a-z0-9]+-[a-z0-9]+"})/sum by (namespace, container) (kube_pod_container_resource_limits{container!="",namespace="tra-production",pod=~"trs-production-authz-[a-z0-9]+-[a-z0-9]+",resource="memory"}) > 0.6
              +     for: 5m
              +     annotations:
              +       summary:     trs-production-authz high memory utilization
              +       description: "Memory utilization has increased in the last 5 minutes (current value: {{ $value | humanizePercentage }})"
              +     labels:
              +       severity:    high
              +       app:         trs-production-authz
              +       receiver: SLACK_WEBHOOK_TRS
              +   - alert: High Memory Utilisation for trs-production-ui
              +     expr: sum by (namespace, container) (container_memory_working_set_bytes{container!="",image!="",namespace="tra-production",pod=~"trs-production-ui-[a-z0-9]+-[a-z0-9]+"})/sum by (namespace, container) (kube_pod_container_resource_limits{container!="",namespace="tra-production",pod=~"trs-production-ui-[a-z0-9]+-[a-z0-9]+",resource="memory"}) > 0.6
              +     for: 5m
              +     annotations:
              +       summary:     trs-production-ui high memory utilization
              +       description: "Memory utilization has increased in the last 5 minutes (current value: {{ $value | humanizePercentage }})"
              +     labels:
              +       severity:    high
              +       app:         trs-production-ui
              +       receiver: SLACK_WEBHOOK_TRS
              +   - alert: High Memory Utilisation for trs-production-worker
              +     expr: sum by (namespace, container) (container_memory_working_set_bytes{container!="",image!="",namespace="tra-production",pod=~"trs-production-worker-[a-z0-9]+-[a-z0-9]+"})/sum by (namespace, container) (kube_pod_container_resource_limits{container!="",namespace="tra-production",pod=~"trs-production-worker-[a-z0-9]+-[a-z0-9]+",resource="memory"}) > 0.6
              +     for: 5m
              +     annotations:
              +       summary:     trs-production-worker high memory utilization
              +       description: "Memory utilization has increased in the last 5 minutes (current value: {{ $value | humanizePercentage }})"
              +     labels:
              +       severity:    high
              +       app:         trs-production-worker
              +       receiver: SLACK_WEBHOOK_TRS
              +   - alert: High Memory Utilisation for teaching-vacancies-production
              +     expr: sum by (namespace, container) (container_memory_working_set_bytes{container!="",image!="",namespace="tv-production",pod=~"teaching-vacancies-production-[a-z0-9]+-[a-z0-9]+"})/sum by (namespace, container) (kube_pod_container_resource_limits{container!="",namespace="tv-production",pod=~"teaching-vacancies-production-[a-z0-9]+-[a-z0-9]+",resource="memory"}) > 0.6
              +     for: 5m
              +     annotations:
              +       summary:     teaching-vacancies-production high memory utilization
              +       description: "Memory utilization has increased in the last 5 minutes (current value: {{ $value | humanizePercentage }})"
              +     labels:
              +       severity:    high
              +       app:         teaching-vacancies-production
              +       receiver: SLACK_WEBHOOK_TV
              +   - alert: High Memory Utilisation for teaching-vacancies-production-worker
              +     expr: sum by (namespace, container) (container_memory_working_set_bytes{container!="",image!="",namespace="tv-production",pod=~"teaching-vacancies-production-worker-[a-z0-9]+-[a-z0-9]+"})/sum by (namespace, container) (kube_pod_container_resource_limits{container!="",namespace="tv-production",pod=~"teaching-vacancies-production-worker-[a-z0-9]+-[a-z0-9]+",resource="memory"}) > 0.6
              +     for: 5m
              +     annotations:
              +       summary:     teaching-vacancies-production-worker high memory utilization
              +       description: "Memory utilization has increased in the last 5 minutes (current value: {{ $value | humanizePercentage }})"
              +     labels:
              +       severity:    high
              +       app:         teaching-vacancies-production-worker
              +       receiver: SLACK_WEBHOOK_TV
            EOT
            # (1 unchanged element hidden)
        }
        id          = "monitoring/prometheus-server-conf"`
## Before merging
<!-- Any extra steps like: delete temp commit, send warning, wait after office hours... -->

## After merging
<!-- Any extra steps like: update other PR, apply manually, inform someone... -->

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
