### PR TITLE
Added production alerts for Find a Teaching School Hub and Register F…

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -79,21 +79,11 @@
     "tra-production/trs-production-ui": {
        "receiver":"SLACK_WEBHOOK_TRS"
     },
-    "tra-production/trs-production-worker": {
-       "receiver":"SLACK_WEBHOOK_TRS"
-    },
     "tv-production/teaching-vacancies-production": {
        "receiver": "SLACK_WEBHOOK_TV",
        "max_cpu": 0.8
     },
-    "tv-production/teaching-vacancies-production-worker": {
-       "receiver": "SLACK_WEBHOOK_TV",
-       "max_cpu": 0.8
-    },
     "tra-production/check-childrens-barred-list-production": {
-       "receiver":"SLACK_WEBHOOK_CCBL"
-    },
-    "tra-production/check-childrens-barred-list-production-worker": {
        "receiver":"SLACK_WEBHOOK_CCBL"
     },
     "tra-production/find-a-lost-trn-production": {
@@ -110,9 +100,6 @@
       "receiver":"SLACK_WEBHOOK_TSH"
     },
     "cpd-production/npq-registration-production-web": {
-      "receiver":"SLACK_WEBHOOK_NPQ"
-    },
-    "cpd-production/npq-registration-production-worker": {
       "receiver":"SLACK_WEBHOOK_NPQ"
     }
   }

--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -46,7 +46,9 @@
     "SLACK_WEBHOOK_TV",
     "SLACK_WEBHOOK_CCBL",
     "SLACK_WEBHOOK_FALTRN",
-    "SLACK_WEBHOOK_GIT"
+    "SLACK_WEBHOOK_GIT",
+    "SLACK_WEBHOOK_NPQ",
+    "SLACK_WEBHOOK_TSH"
   ],
   "alertable_apps": {
     "bat-production/apply-production": {
@@ -103,6 +105,15 @@
     },
     "git-production/getintoteachingapi-production": {
        "receiver":"SLACK_WEBHOOK_GIT"
+    },
+    "cpd-production/cpd-tsh-production": {
+      "receiver":"SLACK_WEBHOOK_TSH"
+    },
+    "cpd-production/npq-registration-production-web": {
+      "receiver":"SLACK_WEBHOOK_NPQ"
+    },
+    "cpd-production/npq-registration-production-worker": {
+      "receiver":"SLACK_WEBHOOK_NPQ"
     }
   }
 }


### PR DESCRIPTION
## Context
Added production alerts for Find a Teaching School Hub and Register F…

## Changes proposed in this pull request
Terraform Plan

`
                      app:         register-sandbox
                      receiver: SLACK_WEBHOOK_RTT
              +   - alert: High Memory Utilisation for cpd-tsh-production
              +     expr: sum by (namespace, container) (container_memory_working_set_bytes{container!="",image!="",namespace="cpd-production",pod=~"cpd-tsh-production-[a-z0-9]+-[a-z0-9]+"})/sum by (namespace, container) (kube_pod_container_resource_limits{container!="",namespace="cpd-production",pod=~"cpd-tsh-production-[a-z0-9]+-[a-z0-9]+",resource="memory"}) > 0.6
              +     for: 5m
              +     annotations:
              +       summary:     cpd-tsh-production high memory utilization
              +       description: "Memory utilization has increased in the last 5 minutes (current value: {{ $value | humanizePercentage }})"
              +     labels:
              +       severity:    high
              +       app:         cpd-tsh-production
              +       receiver: SLACK_WEBHOOK_TSH
              +   - alert: High Memory Utilisation for npq-registration-production-web
              +     expr: sum by (namespace, container) (container_memory_working_set_bytes{container!="",image!="",namespace="cpd-production",pod=~"npq-registration-production-web-[a-z0-9]+-[a-z0-9]+"})/sum by (namespace, container) (kube_pod_container_resource_limits{container!="",namespace="cpd-production",pod=~"npq-registration-production-web-[a-z0-9]+-[a-z0-9]+",resource="memory"}) > 0.6
              +     for: 5m
              +     annotations:
              +       summary:     npq-registration-production-web high memory utilization
              +       description: "Memory utilization has increased in the last 5 minutes (current value: {{ $value | humanizePercentage }})"
              +     labels:
              +       severity:    high
              +       app:         npq-registration-production-web
              +       receiver: SLACK_WEBHOOK_NPQ
              +   - alert: High Memory Utilisation for npq-registration-production-worker
              +     expr: sum by (namespace, container) (container_memory_working_set_bytes{container!="",image!="",namespace="cpd-production",pod=~"npq-registration-production-worker-[a-z0-9]+-[a-z0-9]+"})/sum by (namespace, container) (kube_pod_container_resource_limits{container!="",namespace="cpd-production",pod=~"npq-registration-production-worker-[a-z0-9]+-[a-z0-9]+",resource="memory"}) > 0.6
              +     for: 5m
              +     annotations:
              +       summary:     npq-registration-production-worker high memory utilization
              +       description: "Memory utilization has increased in the last 5 minutes (current value: {{ $value | humanizePercentage }})"
              +     labels:
              +       severity:    high
              +       app:         npq-registration-production-worker
              +       receiver: SLACK_WEBHOOK_NPQ
                  - alert: High Memory Utilisation for get-into-teaching-app-production
`
## Guidance to review
<!-- Show how this can be tested or evidence that it is working -->

## Before merging
<!-- Any extra steps like: delete temp commit, send warning, wait after office hours... -->

## After merging
<!-- Any extra steps like: update other PR, apply manually, inform someone... -->

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
