### PR TITLE
Removed Service type as Loadbalancer

### DIFF
--- a/cluster/terraform_kubernetes/grafana.tf
+++ b/cluster/terraform_kubernetes/grafana.tf
@@ -142,8 +142,6 @@ resource "kubernetes_service" "grafana_service" {
       app = kubernetes_deployment.grafana_deployment.spec[0].template[0].metadata[0].labels["app"]
     }
 
-    type = "LoadBalancer"
-
     port {
       port        = 3000
       target_port = 3000


### PR DESCRIPTION
## Context
Update Grafana service type to ClusterIp , so that it will not exposed to public IP

## Changes proposed in this pull request
Remove service type as LoadBalancer.

## Guidance to review
After deployment verify using below commands there is no External IP for grafana.

   kubectl -n monitoring get svc   

NAME                   TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)             AGE
alertmanager           NodePort    10.0.254.155   <none>        9093:30383/TCP      7d2h
grafana                ClusterIP   10.0.221.216   <none>        3000/TCP            7d2h
kube-state-metrics     ClusterIP   None           <none>        8080/TCP,8081/TCP   7d2h
prometheus             ClusterIP   10.0.230.38    <none>        8080/TCP            7d2h
thanos-querier         ClusterIP   10.0.154.189   <none>        9090/TCP            7d2h
thanos-store-gateway   ClusterIP   None           <none>        10901/TCP           7d2h

Check grafana endpoint is working : https://grafana.cluster3.development.teacherservices.cloud/

## Before merging
<!-- Any extra steps like: delete temp commit, send warning, wait after office hours... -->

## After merging
<!-- Any extra steps like: update other PR, apply manually, inform someone... -->

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
