### PR TITLE
Add thanos reloader for prometheus config changes

### DIFF
--- a/cluster/terraform_kubernetes/config/prometheus/development.prometheus.yml
+++ b/cluster/terraform_kubernetes/config/prometheus/development.prometheus.yml
@@ -14,7 +14,7 @@ global:
   external_labels:
     cluster: prometheus
 rule_files:
-  - /etc/prometheus/app.alert.rules
+  - /etc/prometheus-rules/*rules
 alerting:
   alertmanagers:
   - scheme: http

--- a/cluster/terraform_kubernetes/config/prometheus/platform-test.prometheus.yml
+++ b/cluster/terraform_kubernetes/config/prometheus/platform-test.prometheus.yml
@@ -14,7 +14,7 @@ global:
   external_labels:
     cluster: prometheus
 rule_files:
-  - /etc/prometheus/prometheus.rules
+  - /etc/prometheus-rules/*rules
 alerting:
   alertmanagers:
   - scheme: http

--- a/cluster/terraform_kubernetes/config/prometheus/production.prometheus.yml
+++ b/cluster/terraform_kubernetes/config/prometheus/production.prometheus.yml
@@ -14,7 +14,7 @@ global:
   external_labels:
     cluster: prometheus
 rule_files:
-  - /etc/prometheus/prometheus.rules
+  - /etc/prometheus-rules/*rules
 alerting:
   alertmanagers:
   - scheme: http

--- a/cluster/terraform_kubernetes/config/prometheus/test.prometheus.yml
+++ b/cluster/terraform_kubernetes/config/prometheus/test.prometheus.yml
@@ -14,7 +14,7 @@ global:
   external_labels:
     cluster: prometheus
 rule_files:
-  - /etc/prometheus/prometheus.rules
+  - /etc/prometheus-rules/*rules
 alerting:
   alertmanagers:
   - scheme: http


### PR DESCRIPTION
## Context
Prometheus doesn't reload its config automatically on yml or rules file changes
Add the reloader options to the thanos sidecar to monitor the config and trigger a reload if they are updated.

https://trello.com/c/4UgjfRDA/1714-add-thanos-reloader

## Changes proposed in this pull request
Separate rules directory, config map and mount for alert rules
Add reloader options to the thanos sidecar command

## Guidance to review
- make development terraform-apply ENVIRONMENT=clusterx
- update terraform_kubernetes/config/development.tfvars.json with dummy alertable_apps and alertmanager_slack_receiver_list
- make development terraform-apply ENVIRONMENT=clusterx
- check prometheus & thanos logs and you should see a reload issued within a few minutes
- check changes are reflected in the prometheus ui
- make a change to terraform_kubernetes/config/prometheus/development.prometheus.yml
- make development terraform-apply ENVIRONMENT=clusterx
- check prometheus & thanos logs and you should see a reload issued within a few minutes
- check changes are reflected in the prometheus ui

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
