### PR TITLE
Bug fix for trigger alerts for restart

### DIFF
--- a/cluster/terraform_kubernetes/config/prometheus/alertmanager/app_alert.rules.tmpl
+++ b/cluster/terraform_kubernetes/config/prometheus/alertmanager/app_alert.rules.tmpl
@@ -3,8 +3,8 @@ groups:
   rules:
 %{ for instance in apps ~}
   - alert: High number of restarted containers for ${instance.app_name}
-    expr: sum(rate(kube_pod_container_status_restarts_total{container!="",namespace="${instance.namespace}",pod=~"${instance.app_name}-[a-z0-9]+-[a-z0-9]+"  }[5m]) * 300  ) by (namespace,container) > ${instance.max_crash_count}
-    for: 5m
+    expr: sum(increase(kube_pod_container_status_restarts_total{container!="",namespace="${instance.namespace}",pod=~"${instance.app_name}-[a-z0-9]+-[a-z0-9]+"  }[30m]) ) > 0
+    for: 1m
     annotations:
       summary: High number of restarted containers for ${instance.app_name}
       description: "The rate of container restart has been above ${instance.max_crash_count}  in the last 5 minutes (current value: {{ $value }})"
@@ -44,7 +44,3 @@ groups:
       app:         ${instance.app_name}
       %{ if instance.receiver != null }receiver: ${instance.receiver}%{ endif }
 %{ endfor ~}
-
-
-
-


### PR DESCRIPTION
## Context
Tigger alert for pod restart or Crashloop

## Changes proposed in this pull request
 Updated query for alert 'High number of restarted containers'
## Guidance to review
Tested on cluster3 executing following command so that pod can restart.

1 ) go inside pod : kubectl -n development exec -it register-tope-75b79b7766-qn2xh -- sh 
2 ) Execute command : kill -1 -1.
3 ) check alertmanager https://prometheus.cluster3.development.teacherservices.cloud/alerts ,  alert [High number of restarted containers] will be firing.


## Before merging
<!-- Any extra steps like: delete temp commit, send warning, wait after office hours... -->

## After merging
<!-- Any extra steps like: update other PR, apply manually, inform someone... -->

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
