### PR TITLE
Update review app name in new service template

### DIFF
--- a/templates/new_service/Makefile
+++ b/templates/new_service/Makefile
@@ -16,7 +16,7 @@ development: test-cluster
 .PHONY: review
 review: test-cluster
 	$(if ${PR_NUMBER},,$(error Missing PR_NUMBER))
-	$(eval ENVIRONMENT=${PR_NUMBER})
+	$(eval ENVIRONMENT=review-${PR_NUMBER})
 	$(eval export TF_VAR_environment=${ENVIRONMENT})
 	$(eval include global_config/review.sh)
 


### PR DESCRIPTION
## Context
When using the new service template, review app naming is {service-name}-{pr-number} instead of {service-name}-review-{pr-number}

https://trello.com/c/vDkMKGEI/1753-update-review-app-name-in-new-service-template

## Changes proposed in this pull request
Update ENVIRONMENT value for review apps in template Makefile

## Guidance to review
check code

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
