### PR TITLE
Add log-data-collection-settings config map

### DIFF
--- a/cluster/terraform_kubernetes/analytics.tf
+++ b/cluster/terraform_kubernetes/analytics.tf
@@ -1,0 +1,24 @@
+resource "kubernetes_config_map" "ama_logs" {
+  metadata {
+    name      = "container-azm-ms-agentconfig"
+    namespace = "kube-system"
+  }
+
+  data = {
+    config-version               = "ver1"
+    log-data-collection-settings = <<-EOT
+    # Log data collection settings
+
+    [log_collection_settings]
+        [log_collection_settings.env_var]
+          # In the absense of this configmap, default value for enabled is true
+          enabled = false
+        [log_collection_settings.filter_using_annotations]
+          # if enabled will exclude logs from pods with annotations fluentbit.io/exclude: "true".
+          # Read more: https://docs.fluentbit.io/manual/pipeline/filters/kubernetes#kubernetes-annotations
+          enabled = true
+    EOT
+    schema-version               = "v1"
+  }
+
+}

--- a/documentation/aks-logs.md
+++ b/documentation/aks-logs.md
@@ -1,3 +1,18 @@
+# Log Analytics
+
+Each cluster sends diagnostic log data to a cluster log analytics workspace.
+This can generate a lot of data, at a high cost, so we override some of the default settings.
+
+We have added two settings to ama-logs via config map.
+- Remove env vars from each ContainerInventory entry as it adds a lot of data that's not particularly useful
+    - log_collection_settings.env_var = false
+- Allow exclude of log collection from pods with annotations fluentbit.io/exclude: "true".
+    - log_collection_settings.filter_using_annotations = true
+
+The config map must be called container-azm-ms-agentconfig.
+The ama-logs daemonset has an optional mount for this map, and if one is loaded to the cluster it will automatically mount and restart any ama-logs pods with the new settings.
+see https://github.com/microsoft/Docker-Provider/blob/ci_prod/kubernetes/container-azm-ms-agentconfig.yaml for available variables and default settings.
+
 # Retrieving Log Analytics Data with KQL for AKS Clusters
 
 Kusto Query Language (KQL) is a query language that you can use to retrieve data from Log Analytics workspaces for Azure Kubernetes Service (AKS) clusters. In this guide, we will explain how to write KQL queries to retrieve Log Analytics data and analyze it for your AKS cluster.

--- a/documentation/logit-io.md
+++ b/documentation/logit-io.md
@@ -7,6 +7,9 @@ Once identified, logs will be sent to the cluster BEATS_URL which is contained i
 
 Services that use terraform-modules can enable logit.io logging by adding "enable_logit: true" to app environments.
 
+Enabling logit via the terraform-module will also disable sending logs to the logs analytics workspace for that environment,
+as the module will also add the annotation "fluentbit.io/exclude: true"
+
 ## Account
 The account "Teacher Services UK" was created by Digital tools support, with the help of the Teacher services finance team to input the payment details.
 


### PR DESCRIPTION
## Context

To lower log analytics costs.

## Changes proposed in this pull request

Add two settings to ama-logs via config map.

Remove env vars from each ContainerInventory entry as it adds a lot of data that's not particularly useful 
- log_collection_settings.env_var = false

Allow exclude of log collection from pods with annotations fluentbit.io/exclude: "true".
- log_collection_settings.filter_using_annotations = true

## Guidance to review
Once applied, after a few minutes check ama-logs pods have restarted, then
kubectl -n kube-system logs pod/ama-logs-xxxx
and should see
config::configmap container-azm-ms-agentconfig for settings mounted, parsing values
config::Successfully parsed mounted config map
config::Using config map setting for cluster level environment variable collection
config::INFO: Using config map setting for annotation based log filtering

Check ContainerInventory and any entries should show AZMON_CLUSTER_COLLECT_ENV_VAR=FALSE instead of any env vars.
Adding annotation fluentbit.io/exclude: "true" to a pod should stop any ContainerLog entries.

This has been applied in dev cluster6, with apply-review-rm9 pods excluded via annotation

## Before merging
Will apply manually to platform-test and test clusters

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
