### PR TITLE
OIDC enabled for all clusters

### DIFF
--- a/cluster/terraform_aks_cluster/main.tf
+++ b/cluster/terraform_aks_cluster/main.tf
@@ -8,12 +8,14 @@ data "azurerm_user_assigned_identity" "aks_control_plane" {
 }
 
 resource "azurerm_kubernetes_cluster" "main" {
-  name                = local.cluster_name
-  location            = data.azurerm_resource_group.cluster.location
-  resource_group_name = data.azurerm_resource_group.cluster.name
-  node_resource_group = local.node_resource_group_name
-  dns_prefix          = local.dns_prefix
-  kubernetes_version  = var.kubernetes_version
+  name                      = local.cluster_name
+  location                  = data.azurerm_resource_group.cluster.location
+  resource_group_name       = data.azurerm_resource_group.cluster.name
+  node_resource_group       = local.node_resource_group_name
+  dns_prefix                = local.dns_prefix
+  kubernetes_version        = var.kubernetes_version
+  oidc_issuer_enabled       = true
+  workload_identity_enabled = true
 
   dynamic "azure_active_directory_role_based_access_control" {
     for_each = var.enable_azure_RBAC ? [1] : []


### PR DESCRIPTION
## Context

https://trello.com/c/bLwwt7HH/1758-enable-workload-identity-on-all-clusters

## Changes proposed in this pull request
 Updated flags  oidc_issuer_enabled and workload_identity_enabled to enable OIDC

## Guidance to review
Terraform Plan for test :

 
  ~ update in-place

Terraform will perform the following actions:

  # azurerm_kubernetes_cluster.main will be updated in-place
  ~ resource "azurerm_kubernetes_cluster" "main" {
        id                                  = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-tsc-ts-rg/providers/Microsoft.ContainerService/managedClusters/s189t01-tsc-test-aks"
        name                                = "s189t01-tsc-test-aks"
      ~ oidc_issuer_enabled                 = false -> true
      + oidc_issuer_url                     = (known after apply)
        tags                                = {
            "Environment"      = "Test"
            "Product"          = "Teacher services cloud"
            "Service Offering" = ""
        }
      ~ workload_identity_enabled           = false -> true
        # (26 unchanged attributes hidden)

        # (7 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
 

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
