### PR TITLE
[1800] Reduce false alarms for cpu and memory

### DIFF
--- a/cluster/terraform_kubernetes/config/platform-test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/platform-test.tfvars.json
@@ -1,32 +1,32 @@
 {
-    "cip_tenant": true,
-    "namespaces": [
-      "development",
-      "infra",
-      "monitoring",
-      "qa",
-      "staging",
-      "test"
-    ],
-    "cluster_kv": "s189t01-tsc-pt-kv",
-    "statuscake_alerts": {
-      "tscluster-platform-test": {
-        "website_name": "Teacher-Services-AKS-Cluster-PLATFORM-TEST",
-        "website_url": "https://status.platform-test.teacherservices.cloud/healthz",
-        "check_rate": 60,
-        "contact_group": [
-          282453
-        ]
-      }
-    },
-    "welcome_app_hostnames": [
-      "www.platform-test.teacherservices.cloud"
-    ],
-    "ingress_nginx_version": "4.8.3",
-    "thanos_retention_raw": "3d",
-    "thanos_retention_5m": "3d",
-    "thanos_retention_1h": "3d",
-    "cluster_short": "pt",
-    "alertmanager_slack_receiver_list": [],
-    "alertable_apps": {}
-  }
+  "cip_tenant": true,
+  "namespaces": [
+    "development",
+    "infra",
+    "monitoring",
+    "qa",
+    "staging",
+    "test"
+  ],
+  "cluster_kv": "s189t01-tsc-pt-kv",
+  "statuscake_alerts": {
+    "tscluster-platform-test": {
+      "website_name": "Teacher-Services-AKS-Cluster-PLATFORM-TEST",
+      "website_url": "https://status.platform-test.teacherservices.cloud/healthz",
+      "check_rate": 60,
+      "contact_group": [
+        282453
+      ]
+    }
+  },
+  "welcome_app_hostnames": [
+    "www.platform-test.teacherservices.cloud"
+  ],
+  "ingress_nginx_version": "4.8.3",
+  "thanos_retention_raw": "3d",
+  "thanos_retention_5m": "3d",
+  "thanos_retention_1h": "3d",
+  "cluster_short": "pt",
+  "alertmanager_slack_receiver_list": [],
+  "alertable_apps": {}
+}

--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -54,31 +54,25 @@
   ],
   "alertable_apps": {
     "bat-production/apply-production": {
-       "receiver":"SLACK_WEBHOOK_ATT",
-       "max_cpu": 0.8
+       "receiver":"SLACK_WEBHOOK_ATT"
     },
     "bat-production/apply-sandbox": {
-       "receiver":"SLACK_WEBHOOK_ATT",
-       "max_cpu": 0.8
+       "receiver":"SLACK_WEBHOOK_ATT"
     },
     "bat-production/register-production": {
-       "receiver":"SLACK_WEBHOOK_RTT",
-       "max_cpu": 0.8
+       "receiver":"SLACK_WEBHOOK_RTT"
     },
     "bat-production/register-sandbox": {
-       "receiver":"SLACK_WEBHOOK_RTT",
-       "max_cpu": 0.8
+       "receiver":"SLACK_WEBHOOK_RTT"
     },
     "git-production/get-school-experience-production": {
        "receiver":"SLACK_WEBHOOK_GSE"
     },
     "bat-production/itt-mentor-services-production": {
-      "receiver":"SLACK_WEBHOOK_ITTMS",
-      "max_cpu": 0.8
+      "receiver":"SLACK_WEBHOOK_ITTMS"
     },
     "bat-production/itt-mentor-services-sandbox": {
-      "receiver":"SLACK_WEBHOOK_ITTMS",
-      "max_cpu": 0.8
+      "receiver":"SLACK_WEBHOOK_ITTMS"
     },
     "tra-production/trs-production-api": {
        "receiver":"SLACK_WEBHOOK_TRS"
@@ -90,15 +84,13 @@
        "receiver":"SLACK_WEBHOOK_TRS"
     },
     "tv-production/teaching-vacancies-production": {
-       "receiver": "SLACK_WEBHOOK_TV",
-       "max_cpu": 0.8
+       "receiver": "SLACK_WEBHOOK_TV"
     },
     "tra-production/check-childrens-barred-list-production": {
        "receiver":"SLACK_WEBHOOK_CCBL"
     },
     "tra-production/find-a-lost-trn-production": {
-      "receiver":"SLACK_WEBHOOK_FALTRN",
-      "max_cpu": 0.8
+      "receiver":"SLACK_WEBHOOK_FALTRN"
     },
     "git-production/get-into-teaching-app-production": {
        "receiver":"SLACK_WEBHOOK_GIT"

--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -54,61 +54,61 @@
   ],
   "alertable_apps": {
     "bat-production/apply-production": {
-       "receiver":"SLACK_WEBHOOK_ATT"
+      "receiver": "SLACK_WEBHOOK_ATT"
     },
     "bat-production/apply-sandbox": {
-       "receiver":"SLACK_WEBHOOK_ATT"
+      "receiver": "SLACK_WEBHOOK_ATT"
     },
     "bat-production/register-production": {
-       "receiver":"SLACK_WEBHOOK_RTT"
+      "receiver": "SLACK_WEBHOOK_RTT"
     },
     "bat-production/register-sandbox": {
-       "receiver":"SLACK_WEBHOOK_RTT"
+      "receiver": "SLACK_WEBHOOK_RTT"
     },
     "git-production/get-school-experience-production": {
-       "receiver":"SLACK_WEBHOOK_GSE"
+      "receiver": "SLACK_WEBHOOK_GSE"
     },
     "bat-production/itt-mentor-services-production": {
-      "receiver":"SLACK_WEBHOOK_ITTMS"
+      "receiver": "SLACK_WEBHOOK_ITTMS"
     },
     "bat-production/itt-mentor-services-sandbox": {
-      "receiver":"SLACK_WEBHOOK_ITTMS"
+      "receiver": "SLACK_WEBHOOK_ITTMS"
     },
     "tra-production/trs-production-api": {
-       "receiver":"SLACK_WEBHOOK_TRS"
+      "receiver": "SLACK_WEBHOOK_TRS"
     },
     "tra-production/trs-production-authz": {
-       "receiver":"SLACK_WEBHOOK_TRS"
+      "receiver": "SLACK_WEBHOOK_TRS"
     },
     "tra-production/trs-production-ui": {
-       "receiver":"SLACK_WEBHOOK_TRS"
+      "receiver": "SLACK_WEBHOOK_TRS"
     },
     "tv-production/teaching-vacancies-production": {
-       "receiver": "SLACK_WEBHOOK_TV"
+      "receiver": "SLACK_WEBHOOK_TV"
     },
     "tra-production/check-childrens-barred-list-production": {
-       "receiver":"SLACK_WEBHOOK_CCBL"
+      "receiver": "SLACK_WEBHOOK_CCBL"
     },
     "tra-production/find-a-lost-trn-production": {
-      "receiver":"SLACK_WEBHOOK_FALTRN"
+      "receiver": "SLACK_WEBHOOK_FALTRN"
     },
     "git-production/get-into-teaching-app-production": {
-       "receiver":"SLACK_WEBHOOK_GIT"
+      "receiver": "SLACK_WEBHOOK_GIT"
     },
     "git-production/getintoteachingapi-production": {
-       "receiver":"SLACK_WEBHOOK_GIT"
+      "receiver": "SLACK_WEBHOOK_GIT"
     },
     "cpd-production/npq-registration-production-web": {
-      "receiver":"SLACK_WEBHOOK_NPQ"
+      "receiver": "SLACK_WEBHOOK_NPQ"
     },
     "bat-production/publish-production": {
-      "receiver":"SLACK_WEBHOOK_PTT"
+      "receiver": "SLACK_WEBHOOK_PTT"
     },
     "cpd-production/cpd-tsh-sandbox": {
-      "receiver":"SLACK_WEBHOOK_CPD"
+      "receiver": "SLACK_WEBHOOK_CPD"
     },
     "cpd-production/cpd-tsh-production": {
-      "receiver":"SLACK_WEBHOOK_CPD"
-   }
+      "receiver": "SLACK_WEBHOOK_CPD"
+    }
   }
 }

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -54,13 +54,13 @@
       "receiver": "SLACK_WEBHOOK_RTT"
     },
     "git-test/get-school-experience-staging": {
-      "receiver":"SLACK_WEBHOOK_GSE"
+      "receiver": "SLACK_WEBHOOK_GSE"
     },
     "git-test/get-into-teaching-app-test": {
-      "receiver":"SLACK_WEBHOOK_GIT"
+      "receiver": "SLACK_WEBHOOK_GIT"
     },
     "git-test/getintoteachingapi-test": {
-      "receiver":"SLACK_WEBHOOK_GIT"
+      "receiver": "SLACK_WEBHOOK_GIT"
     },
     "bat-staging/itt-mentor-services-staging": {
       "receiver": "SLACK_WEBHOOK_ITTMS"

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -45,18 +45,13 @@
   "cluster_short": "ts",
   "alertable_apps": {
     "bat-qa/apply-qa": {
-      "receiver": "SLACK_WEBHOOK_ATT",
-      "max_cpu": 0.8,
-      "max_mem": 0.8
+      "receiver": "SLACK_WEBHOOK_ATT"
     },
     "bat-staging/apply-staging": {
-      "receiver": "SLACK_WEBHOOK_ATT",
-      "max_cpu": 0.8,
-      "max_mem": 0.8
+      "receiver": "SLACK_WEBHOOK_ATT"
     },
     "bat-staging/register-staging": {
-      "receiver": "SLACK_WEBHOOK_RTT",
-      "max_cpu": 0.8
+      "receiver": "SLACK_WEBHOOK_RTT"
     },
     "git-test/get-school-experience-staging": {
       "receiver":"SLACK_WEBHOOK_GSE"

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -260,8 +260,8 @@ locals {
     apps = [for instance, settings in var.alertable_apps : {
       namespace       = split("/", instance)[0]
       app_name        = split("/", instance)[1]
-      max_cpu         = try(settings.max_cpu, 0.6)
-      max_mem         = try(settings.max_mem, 0.6)
+      max_cpu         = try(settings.max_cpu, 0.8)
+      max_mem         = try(settings.max_mem, 0.8)
       max_crash_count = try(settings.max_crash_count, 1)
       receiver        = try(settings.receiver, "SLACK_WEBHOOK_GENERIC")
       }


### PR DESCRIPTION
## Context
Frequest false alarms such as https://ukgovernmentdfe.slack.com/archives/C05D5S8C6PJ/p1715079379398809

## Changes proposed in this pull request
- Change the thresholds to 80%
- Remove the overrides when they are the same
- Fix json formatting

## Guidance to review
Run terraform plan

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
