### PR TITLE
Add data collection rule for ContainerInsight logs

### DIFF
--- a/cluster/terraform_aks_cluster/analytics.tf
+++ b/cluster/terraform_aks_cluster/analytics.tf
@@ -39,3 +39,48 @@ resource "azurerm_monitor_diagnostic_setting" "aks_system_logs" {
     enabled  = false
   }
 }
+
+# Using a data collection rule to change the Container Insights data collection settings
+# see https://learn.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-data-collection-dcr?tabs=cli
+
+resource "azurerm_monitor_data_collection_rule" "aks" {
+  name                = "${var.resource_prefix}-tsc-${var.environment}-dcr"
+  resource_group_name = data.azurerm_resource_group.cluster.name
+  location            = data.azurerm_resource_group.cluster.location
+
+  lifecycle { ignore_changes = [tags] }
+
+  destinations {
+    log_analytics {
+      name                  = "${var.resource_prefix}-tsc-${var.environment}-log-analytics-destination"
+      workspace_resource_id = azurerm_log_analytics_workspace.aks_system_logs.id
+    }
+  }
+
+  data_flow {
+    streams      = ["Microsoft-ContainerInsights-Group-Default"]
+    destinations = ["${var.resource_prefix}-tsc-${var.environment}-log-analytics-destination"]
+  }
+
+  data_sources {
+    extension {
+      name = "ContainerInsightsExtension"
+      # see https://learn.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-transformations#data-sources
+      streams        = ["Microsoft-ContainerInsights-Group-Default"]
+      extension_name = "ContainerInsights"
+      extension_json = jsonencode({
+        dataCollectionSettings = {
+          interval               = var.ci_collection_interval
+          namespaceFilteringMode = "Off"
+          enableContainerLogV2   = true
+        }
+      })
+    }
+  }
+}
+
+resource "azurerm_monitor_data_collection_rule_association" "aks" {
+  name                    = "${var.resource_prefix}-tsc-${var.environment}-dcr-assoc"
+  target_resource_id      = azurerm_kubernetes_cluster.main.id
+  data_collection_rule_id = azurerm_monitor_data_collection_rule.aks.id
+}

--- a/cluster/terraform_aks_cluster/config/production.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/production.tfvars.json
@@ -17,5 +17,6 @@
     }
   },
   "admin_group_id": "5b0f84de-54a8-481a-8689-f3c226597259",
-  "enable_azure_RBAC": true
+  "enable_azure_RBAC": true,
+  "ci_collection_interval": "1m"
 }

--- a/cluster/terraform_aks_cluster/main.tf
+++ b/cluster/terraform_aks_cluster/main.tf
@@ -29,7 +29,8 @@ resource "azurerm_kubernetes_cluster" "main" {
   local_account_disabled = var.enable_azure_RBAC
 
   oms_agent {
-    log_analytics_workspace_id = azurerm_log_analytics_workspace.aks_system_logs.id
+    log_analytics_workspace_id      = azurerm_log_analytics_workspace.aks_system_logs.id
+    msi_auth_for_monitoring_enabled = true
   }
 
   default_node_pool {

--- a/cluster/terraform_aks_cluster/variables.tf
+++ b/cluster/terraform_aks_cluster/variables.tf
@@ -8,6 +8,10 @@ variable "managed_identity_name" {
   type        = string
   description = "Name of the managed identiy assumed by the cluster for its control plane"
 }
+variable "ci_collection_interval" {
+  default     = "5m"
+  description = "Container Insights data collection interval"
+}
 
 # Set in config json file
 variable "cip_tenant" { type = bool }

--- a/documentation/developer-onboarding.md
+++ b/documentation/developer-onboarding.md
@@ -112,18 +112,18 @@ The standard output from all applications is captured in [Azure Log analytics](h
 
 All logs from all the services on the cluster:
 ```
-ContainerLog
+ContainerLogV2
 ```
 
 Full text search for "Exception":
 ```
-ContainerLog
+ContainerLogV2
 | where LogEntry contains "Exception"
 ```
 
 Decode the LogEntry json to query it:
 ```
-ContainerLog
+ContainerLogV2
 | extend log_entry = parse_json(LogEntry)
 | where log_entry.host contains "register"
 | where log_entry.environment == "production"
@@ -131,7 +131,7 @@ ContainerLog
 
 Only show the timestamp and LogEntry columns:
 ```
-ContainerLog
+ContainerLogV2
 | extend log_entry = parse_json(LogEntry)
 | where log_entry.host contains "register"
 | project TimeGenerated, log_entry
@@ -139,6 +139,6 @@ ContainerLog
 
 HTTP requests from the ingress controller, using the filter from [ingress controller logs](#ingress-controller):
 ```
-ContainerLog
+ContainerLogV2
 | where LogEntry contains "cpd-production-cpd-ecf-production-web-80"
 ```


### PR DESCRIPTION
## Context
From the Log Analytics review, add a data collection rule to select Container Insights logs we want and collection interval 

https://trello.com/c/JLoTqyxU/1795-add-data-collection-rule-for-cluster-monitor-data

## Changes proposed in this pull request
- add data collection rule
- increase collection interval to 5m for non-prod clusters
- update omsagent auth, required for DCR 
- update dev documentation to reference ContainerLogV2 instead of ContainerLog

## Guidance to review
deploy a dev cluster and check logs are as expected 

## Before merging
Confirm there isn't any cluster outage on update 
- tested on cluster5 with apply review app and there was no service interruption during the update

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
