### PR TITLE
Increase thanos store gateway to 3G mem

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -36,7 +36,7 @@
   "thanos_querier_mem": "2Gi",
   "thanos_app_cpu": "0.5",
   "thanos_compactor_mem": "5Gi",
-  "thanos_store_mem": "2Gi",
+  "thanos_store_mem": "3Gi",
   "cluster_short": "pd",
   "alertmanager_slack_receiver_list": [
     "SLACK_WEBHOOK_ATT",

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -39,7 +39,7 @@
   "prometheus_app_mem": "12Gi",
   "prometheus_app_cpu": "0.5",
   "thanos_querier_mem": "2Gi",
-  "thanos_store_mem": "2Gi",
+  "thanos_store_mem": "3Gi",
   "thanos_compactor_mem": "5Gi",
   "thanos_app_cpu": "0.5",
   "cluster_short": "ts",


### PR DESCRIPTION
## Context
Thanos store gateway failing in test and prod clusters as 2G memory is insufficient

## Changes proposed in this pull request
Increase to 3G

## Guidance to review
make test terraform-plan

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
