### PR TITLE
Test cluster max node count set to 25

### DIFF
--- a/cluster/terraform_aks_cluster/config/test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/test.tfvars.json
@@ -8,7 +8,7 @@
   "node_pools": {
     "apps1": {
       "min_count": 2,
-      "max_count": 20,
+      "max_count": 25,
       "vm_size": "Standard_E4ads_v5",
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"


### PR DESCRIPTION

## Context
Add more nodes to test cluster.
## Changes proposed in this pull request
 apps1 node pools max_count updated to 25

## Guidance to review
Terraform Plan  

`

  # azurerm_kubernetes_cluster_node_pool.node_pools["apps1"] will be updated in-place
  ~ resource "azurerm_kubernetes_cluster_node_pool" "node_pools" {
        id                      = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-tsc-ts-rg/providers/Microsoft.ContainerService/managedClusters/s189t01-tsc-test-aks/agentPools/apps1"
      ~ max_count               = 20 -> 25
        name                    = "apps1"
        tags                    = {}
        # (25 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
`
## After merging
<!-- Any extra steps like: update other PR, apply manually, inform someone... -->

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
