### PR TITLE
Add docs and scripts for Azure -> GCP workload identity federation

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,3 +201,4 @@ The teacherservices.cloud domain is created in route53 and owned by infra-ops. S
 - [Low priority app](documentation/lowpriority-app.md)
 - [Monitoring](documentation/monitoring.md)
 - [Slack webhook integration](documentation/slack-webhook-integration.md)
+- [Azure GCP Workload Identity Federation](documentation/azure-gcp-workload-identity-federation.md)

--- a/documentation/azure-gcp-workload-identity-federation.md
+++ b/documentation/azure-gcp-workload-identity-federation.md
@@ -10,7 +10,7 @@ To configure GCP run the gcloud scripts below.
 
 ### Pre-requisites for running gcloud scripts
 
-- Install the gcloud cli for you operating system
+- [Install the gcloud CLI](https://cloud.google.com/sdk/docs/install) for you operating system
 - A google account is required. This can be requested from ServiceNow or contact the #twd_data_insights team on slack
 - **Owner** permissions are required for the project to be configured. This can be requested from the #twd_data_insights team on slack
 - Authenticate with gcloud on the cli to run the scripts below

--- a/documentation/azure-gcp-workload-identity-federation.md
+++ b/documentation/azure-gcp-workload-identity-federation.md
@@ -1,0 +1,23 @@
+# Azure GCP Workload Identity Federation
+
+This allows Azure AKS client to access GCP resources without the use of plain text API Keys, that are considered a security risk.
+
+Workload Identity Federation requires configuration on both Azure and GCP.
+
+## GCP Configuration
+
+### Create a workload identity pool
+
+GCloud bash script:
+
+```
+create-gcp-workload-identity-pool.sh
+```
+
+### Create a workload identity pool provider
+
+GCloud bash script:
+
+```
+create-gcp-workload-identity-pool-provider.sh
+```

--- a/documentation/azure-gcp-workload-identity-federation.md
+++ b/documentation/azure-gcp-workload-identity-federation.md
@@ -6,18 +6,41 @@ Workload Identity Federation requires configuration on both Azure and GCP.
 
 ## GCP Configuration
 
-### Create a workload identity pool
+To configure GCP run the gcloud scripts below.
 
-GCloud bash script:
+### Pre-requisites for running gcloud scripts
+
+- Install the gcloud cli for you operating system
+- A google account is required. This can be requested from ServiceNow or contact the #twd_data_insights team on slack
+- **Owner** permissions are required for the project to be configured. This can be requested from the #twd_data_insights team on slack
+- Authenticate with gcloud on the cli to run the scripts below
+
+### Authenticating with gcloud
+
+Login with the following gcloud command to authenticate through a browser:
 
 ```
-create-gcp-workload-identity-pool.sh
+gcloud auth login
+```
+
+For convenience to set defaults run the init command and follow the prompts:
+
+```
+gcloud init
+```
+
+### Create a workload identity pool
+
+gcloud shell script:
+
+```
+scripts/azure-gcp-wif/create-gcp-workload-identity-pool.sh
 ```
 
 ### Create a workload identity pool provider
 
-GCloud bash script:
+gcloud shell script:
 
 ```
-create-gcp-workload-identity-pool-provider.sh
+scripts/azure-gcp-wif/create-gcp-workload-identity-pool-provider.sh
 ```

--- a/scripts/azure-gcp-wif/create-gcp-workload-identity-pool-provider.sh
+++ b/scripts/azure-gcp-wif/create-gcp-workload-identity-pool-provider.sh
@@ -1,16 +1,17 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # Requires gcloud cli and authentication with gcloud:
 # - gcloud init
 # - gcloud auth login
 PROJECT="rugged-abacus-218110"
-
+AZURE_TENANT_ID="9c7d9dd3-840c-4b3f-818e-552865082e16"
+AZURE_AD_TOKEN_EXCHANGE_APP_ID="fb60f99c-7a34-4190-8149-302f77469936"
 # Create workload identity pool
 # NOTE: must be "global" region (Can't use for example "europe-west2")
 gcloud iam workload-identity-pools providers create-oidc azure-cip-oidc-provider \
  --location="global" \
  --workload-identity-pool="azure-cip-identity-pool" \
- --issuer-uri="https://login.microsoftonline.com/9c7d9dd3-840c-4b3f-818e-552865082e16/v2.0" \
- --allowed-audiences="fb60f99c-7a34-4190-8149-302f77469936" \
+ --issuer-uri="https://login.microsoftonline.com/$AZURE_TENANT_ID/v2.0" \
+ --allowed-audiences="$AZURE_AD_TOKEN_EXCHANGE_APP_ID" \
  --attribute-mapping="google.subject=assertion.sub" \
  --project=$PROJECT

--- a/scripts/azure-gcp-wif/create-gcp-workload-identity-pool-provider.sh
+++ b/scripts/azure-gcp-wif/create-gcp-workload-identity-pool-provider.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Requires gcloud cli and authentication with gcloud:
+# - gcloud init
+# - gcloud auth login
+PROJECT="rugged-abacus-218110"
+
+# Create workload identity pool
+# NOTE: must be "global" region (Can't use for example "europe-west2")
+gcloud iam workload-identity-pools providers create-oidc azure-cip-oidc-provider \
+ --location="global" \
+ --workload-identity-pool="azure-cip-identity-pool" \
+ --issuer-uri="https://login.microsoftonline.com/9c7d9dd3-840c-4b3f-818e-552865082e16/v2.0" \
+ --allowed-audiences="fb60f99c-7a34-4190-8149-302f77469936" \
+ --attribute-mapping="google.subject=assertion.sub" \
+ --project=$PROJECT

--- a/scripts/azure-gcp-wif/create-gcp-workload-identity-pool-provider.sh
+++ b/scripts/azure-gcp-wif/create-gcp-workload-identity-pool-provider.sh
@@ -6,6 +6,7 @@
 PROJECT="rugged-abacus-218110"
 AZURE_TENANT_ID="9c7d9dd3-840c-4b3f-818e-552865082e16"
 AZURE_AD_TOKEN_EXCHANGE_APP_ID="fb60f99c-7a34-4190-8149-302f77469936"
+
 # Create workload identity pool
 # NOTE: must be "global" region (Can't use for example "europe-west2")
 gcloud iam workload-identity-pools providers create-oidc azure-cip-oidc-provider \

--- a/scripts/azure-gcp-wif/create-gcp-workload-identity-pool.sh
+++ b/scripts/azure-gcp-wif/create-gcp-workload-identity-pool.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # Requires gcloud cli and authentication with gcloud:
 # - gcloud init

--- a/scripts/azure-gcp-wif/create-gcp-workload-identity-pool.sh
+++ b/scripts/azure-gcp-wif/create-gcp-workload-identity-pool.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Requires gcloud cli and authentication with gcloud:
+# - gcloud init
+# - gcloud auth login
+PROJECT="rugged-abacus-218110"
+
+# Create workload identity pool
+# NOTE: must be "global" region (Can't use for example "europe-west2")
+gcloud iam workload-identity-pools create azure-cip-identity-pool \
+ --location="global" \
+ --description="Azure CIP -> GCP Workload identity pool" \
+ --display-name="azure-cip-identity-pool" \
+ --project=$PROJECT


### PR DESCRIPTION

## Context
Add scripts and docs for workload identity federation. Trello card [here](https://trello.com/c/nbML53b1).

## Changes proposed in this pull request
- Scripts for creating a workload identity pool and provider on GCP
- Basic documentation 

## Guidance to review
- Requires gcloud CLI and login for testing

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
