### PR TITLE
 azure/login action updated to use v2

### DIFF
--- a/.github/actions/deploy-environment/action.yml
+++ b/.github/actions/deploy-environment/action.yml
@@ -58,7 +58,7 @@ runs:
     shell: bash
     working-directory: cluster
 
-  - uses: Azure/login@v1
+  - uses: Azure/login@v2
     with:
       creds: ${{ inputs.azure_credentials }}
 


### PR DESCRIPTION

## Context
   azure/login action updated to use v2 to supress warning on node16 on pipelines.

## Changes proposed in this pull request
Action  azure/login updated to use v2
## Guidance to review
There should be no warning related to node16 in pipeline.  

 

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
