### PR TITLE
Fixed filter Controller Success Rate by adding namespace and ingress

### DIFF
--- a/cluster/terraform_kubernetes/config/dashboards/nginx-ingress-controller.json
+++ b/cluster/terraform_kubernetes/config/dashboards/nginx-ingress-controller.json
@@ -274,9 +274,11 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\",status!~\"[4-5].*\"}[2m])) / sum(rate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\"}[2m]))",
+          "editorMode": "code",
+          "expr": "sum(rate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$exported_namespace\",ingress=~\"$ingress\",status!~\"[4-5].*\"}[2m])) / sum(rate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$exported_namespace\",ingress=~\"$ingress\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 1,
+          "range": true,
           "refId": "A",
           "step": 4
         }


### PR DESCRIPTION
## Context
Filter by ingress is not working for ‘Controller Success Rate (non-4|5xx responses)’ on ingress dashboard.

## Changes proposed in this pull request
Updated query by passing namespace and ingress
## Guidance to review
 Deployed on test : https://grafana.test.teacherservices.cloud/d/nginx-test/nginx-ingress-controller-test.

Selected filter ingress namespace and ingress and check 'Controller Success Rate (non-4|5xx responses)'

 

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
