### PR TITLE
Production AKS Upgraded to 1.27.9

### DIFF
--- a/cluster/terraform_aks_cluster/config/production.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/production.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.27.7",
+  "kubernetes_version": "1.27.9",
   "default_node_pool": {
     "node_count": 3,
-    "orchestrator_version": "1.27.7"
+    "orchestrator_version": "1.27.9"
   },
   "node_pools": {
     "apps1": {
@@ -13,7 +13,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.27.7"
+      "orchestrator_version": "1.27.9"
     }
   },
   "admin_group_id": "5b0f84de-54a8-481a-8689-f3c226597259",


### PR DESCRIPTION
 
## Context
Production AKS Upgraded to 1.27.9.

## Changes proposed in this pull request
Production AKS Upgraded to 1.27.9
## Guidance to review
 Connect production cluster  : make production get-cluster-credentials CONFIRM_PRODUCTION=yes
 Execute following command to check server version : kubectl version
 

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
