### PR TITLE
Increase proxy body size to 50MB

### DIFF
--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -49,7 +49,7 @@ resource "helm_release" "ingress-nginx" {
   # Allow POST requests with large body. Prevent error 413: Request entity too large
   set {
     name  = "controller.config.proxy-body-size"
-    value = "8m"
+    value = "50m"
     type  = "string"
   }
   # Sets the size of the buffer used for reading the first part of the response received from the proxied server.


### PR DESCRIPTION
The Apply for QTS service allows users to upload files up to 50 MB in size, so we need to ensure that the Nginx ingress proxy is be able to handle client body requests of that size.