### PR TITLE
Update maintenance page template

### DIFF
--- a/documentation/maintenance-page.md
+++ b/documentation/maintenance-page.md
@@ -46,10 +46,12 @@ flowchart LR;
 ```
 
 ## Initial configuration
+- Ensure docker is installed and running locally
 - Use the template as described in [Onboard a new service to the Teacher Services AKS cloud platform](onboard-service.md)
 - Check the content by opening `new_service/maintenance_page/html/index.html` in a browser and edit the HTML content as needed, including the email in the footer
 - Check the domains and kubernetes resource names in `new_service/maintenance_page/manifests`
 - Only production and development environments are provided as examples. Copy and amend for new environments.
+- Create workflows for enable-maintenance and disable-maintenance similar to https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/.github/workflows/enable-maintenance.yml and https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/.github/workflows/disable-maintenance.yml
 - Test in each environment
 
 ## Update content

--- a/templates/new_service/Makefile
+++ b/templates/new_service/Makefile
@@ -135,7 +135,7 @@ bin/konduit.sh:
 
 maintenance-image-push:
 	$(if ${GITHUB_TOKEN},, $(error Provide a valid Github token with write:packages permissions as GITHUB_TOKEN variable))
-	$(if ${MAINTENANCE_IMAGE_TAG},, $(eval MAINTENANCE_IMAGE_TAG=$(date +%s)))
+	$(if ${MAINTENANCE_IMAGE_TAG},, $(eval export MAINTENANCE_IMAGE_TAG=$(shell date +%s)))
 	docker build -t ghcr.io/dfe-digital/#SERVICE_NAME#-maintenance:${MAINTENANCE_IMAGE_TAG} maintenance_page
 	echo ${GITHUB_TOKEN} | docker login ghcr.io -u USERNAME --password-stdin
 	docker push ghcr.io/dfe-digital/#SERVICE_NAME#-maintenance:${MAINTENANCE_IMAGE_TAG}


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
We need to update the maintenance template so it is easier to follow for implementation on services

## Changes proposed in this pull request

- https://github.com/DFE-Digital/teacher-services-cloud/blob/main/templates/new_service/Makefile#L138 needs to be $(if ${MAINTENANCE_IMAGE_TAG},, $(eval export MAINTENANCE_IMAGE_TAG=$(shell date +%s)))

- Document the need for docker to be installed locally and running

- Step to create workflows for enable-maintenance and disable-maintenance


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
