### PR TITLE
Ignore failures on cleanup step

### DIFF
--- a/scripts/konduit.sh
+++ b/scripts/konduit.sh
@@ -330,4 +330,4 @@ open_tunnels >/dev/null 2>&1
 sleep 5 # Need to allow the connections to open
 $CMD    # Run the command
 echo Running cleanup...
-cleanup >/dev/null 2>&1 # Cleanup on completion
+cleanup >/dev/null 2>&1 || true # Cleanup on completion


### PR DESCRIPTION
## Context
konduit will complete with a failure code if there is any failure in the cleanup step.
This causes workflows that use konduit to fail.

https://trello.com/c/rIg0hcYY/1892-konduit-ignore-cleanup-failures 

## Changes proposed in this pull request
Update konduit to always complete the cleanup step with a success code

## Guidance to review
konduit.sh some-env -- psql

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
