### PR TITLE
Add update image tag step for the maintenance page template

### DIFF
--- a/templates/new_service/maintenance_page/scripts/failback.sh
+++ b/templates/new_service/maintenance_page/scripts/failback.sh
@@ -21,5 +21,9 @@ kubectl -n ${NAMESPACE} delete  --ignore-not-found=true -f maintenance_page/mani
 echo Delete maintenance service
 kubectl -n ${NAMESPACE} delete  --ignore-not-found=true -f maintenance_page/manifests/maintenance/service_maintenance.yml
 
+echo Update image tag
+perl -p -e "s/#MAINTENANCE_IMAGE_TAG#/dummy-tag/" maintenance_page/manifests/maintenance/deployment_maintenance.yml.tmpl \
+    > maintenance_page/manifests/maintenance/deployment_maintenance.yml
+
 echo Delete maintenance app
 kubectl -n ${NAMESPACE} delete  --ignore-not-found=true -f maintenance_page/manifests/maintenance/deployment_maintenance.yml


### PR DESCRIPTION

<!-- Delete sections if not required -->

## Context
There was a missing step in the maintenance page template

## Changes proposed in this pull request
Add update image tag step into failback.sh for the maintenance page template


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
