### PR TITLE
[1750 Fix domain naming in template script

### DIFF
--- a/templates/new_service.sh
+++ b/templates/new_service.sh
@@ -2,9 +2,8 @@
 
 set -eu
 
-DOMAINS_RESOURCE_GROUP_NAME="s189p01-${SERVICE_SHORT}-domains-rg"
-FRONT_DOOR_NAME="s189p01-${SERVICE_SHORT}-domains-fd"
-FRONT_DOOR_NAME="s189p01-${SERVICE_SHORT}-domains-fd"
+DOMAINS_RESOURCE_GROUP_NAME="s189p01-${SERVICE_SHORT}-dom-rg"
+FRONT_DOOR_NAME="s189p01-${SERVICE_SHORT}-dom-fd"
 
 echo Copying files to ./new_service ...
 cp -r templates/new_service .


### PR DESCRIPTION
## Context
The naming of azure resources was not consistent

## Changes proposed in this pull request
Fix naming in the template script

## Guidance to review
Run:
```
make new_service SERVICE_NAME=claim-additional-payments-for-teaching SERVICE_PRETTY="Claim additional payments for teaching" SERVICE_SHORT=capt DOCKER_REPOSITORY=ghcr.io/dfe-digital/claim-additional-payments-for-teaching NAMESPACE_PREFIX=srtl DNS_ZONE_NAME=claim-additional-teaching-payment.service.gov.uk
```
And check the generated domain files

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
