### PR TITLE
AKS Upgrade 1.28.9 on dev and platform-test

### DIFF
--- a/cluster/terraform_aks_cluster/config/development.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/development.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.27.9",
+  "kubernetes_version": "1.28.9",
   "default_node_pool": {
     "node_count": 1,
-    "orchestrator_version": "1.27.9"
+    "orchestrator_version": "1.28.9"
   },
   "node_pools": {
     "apps1": {
@@ -12,7 +12,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.27.9"
+      "orchestrator_version": "1.28.9"
     }
   },
   "admin_group_id": "f77b2daf-7ff4-4aa5-8138-cf983d0b4a18",

--- a/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.27.9",
+  "kubernetes_version": "1.28.9",
   "default_node_pool": {
     "node_count": 2,
-    "orchestrator_version": "1.27.9"
+    "orchestrator_version": "1.28.9"
   },
   "node_pools": {
     "apps1": {
@@ -12,7 +12,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.27.9"
+      "orchestrator_version": "1.28.9"
     }
   },
   "admin_group_id": "f726cc54-78cb-4c98-89a6-b8e4396afb98",


### PR DESCRIPTION

## Context
AKS Upgrade to 1.28.9 on dev and platform-test cluster.

 
## Guidance to review
Dev Cluster and Platform test cluster upgraded.

## Before merging
Verify platform test cluster already upgraded  check using 'kubectl get  node' .

 

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
