### PR TITLE
Drop route error stack traces

### DIFF
--- a/documentation/logit-io.md
+++ b/documentation/logit-io.md
@@ -121,6 +121,13 @@ filter {
       remove_field => ["message"]
     }
 
+    # Remove stack trace for 404 errors in rails apps, as it is large and adds no value
+    if [app][exception][name] == "ActionController::RoutingError" {
+      mutate {
+        remove_field => "[app][exception][stack_trace]"
+      }
+    }
+
     # Encode HTTP params as json string to avoid indexing thousands of fields
     json_encode {
       source => "[app][payload][params]"


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
All rails 404 route error requests return a large stack trace to the logs, which we send to the logs.

Will be slow to get all the services to fix, so might be easier to drop in logit.

https://kibana-uk1.logit.io/s/e9b9162d-0b5e-4362-bed0-8e577f88d06e/app/discover#/doc/filebeat-*/filebeat-2024.07.08?id=GNWDkZABnFDrG26tbgNT

## Changes proposed in this pull request
Add a filter to drop app.exception.stack_trace if [app.exception.name] is "ActionController::RoutingError" 

## Guidance to review
No more stack traces in logit for these messages


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
