### PR TITLE
[1863] Update konduit to pass database URL

### DIFF
--- a/scripts/konduit.sh
+++ b/scripts/konduit.sh
@@ -171,7 +171,7 @@ set_db_psql() {
    else
       ORIG_URL=$(az keyvault secret show --name "${DBName}"-database-url --vault-name "${KV}" | jq -r .value)
    fi
-   DB_URL=$(echo "${ORIG_URL}" | sed "s/@[^~]*\//@127.0.0.1:${LOCAL_PORT}\//g")
+   DB_URL=$(echo "${ORIG_URL}" | sed "s|@.*/|@127.0.0.1:${LOCAL_PORT}/|g")
    DB_HOSTNAME=$(echo "${ORIG_URL}" | awk -F"@" '{print $2}' | awk -F":" '{print $1}')
 
    # Override the database name if requested
@@ -203,10 +203,10 @@ set_db_redis() {
    fi
 
    if [ "${AKS}" = "" ]; then
-      DB_URL=$(echo "${ORIG_URL}" | sed "s/@[^~]*\//@127.0.0.1:${LOCAL_PORT}\//g" | sed "s/rediss:\/\//rediss:\/\/default/g")
+      DB_URL=$(echo "${ORIG_URL}" | sed "s|@.*/|@127.0.0.1:${LOCAL_PORT}/|g" | sed "s|rediss://|rediss://default|g")
       DB_HOSTNAME=$(echo "${ORIG_URL}" | awk -F"@" '{print $2}' | awk -F":" '{print $1}')
    else
-      DB_URL=$(echo "$ORIG_URL" | sed "s/\/\/[^~]*/\/\/127.0.0.1:${LOCAL_PORT}\//g")
+      DB_URL=$(echo "$ORIG_URL" | sed "s|//.*|//127.0.0.1:${LOCAL_PORT}/|g")
       DB_HOSTNAME=$(echo "$ORIG_URL" | awk -F"/" '{print $3}' | awk -F":" '{print $1}')
    fi
 


### PR DESCRIPTION
## Context
Simplify use of konduit when using a non default database or database server. Useful in case of an incident.

## Changes proposed in this pull request
- Override database name
- Override database server
- Simplify some parts of the code

## Guidance to review
### Override postgres database name of apply qa
- Connect to apply-qa postgres: `scripts/konduit.sh  apply-qa -- psql`
- Create new database: `create database abcd123;`
- Connect to new postgres: `scripts/konduit.sh -d abcd123 apply-qa -- psql`
- Delete temp database: `drop database abcd123;` ⚠️ 

### Override redis database name of apply qa
- Connect to apply-qa redis default DB: `scripts/konduit.sh  apply-qa -- redis-cli`
- Connect to apply-qa redis DB database 1: `scripts/konduit.sh -d 1 apply-qa -- redis-cli`

### Override postgres database server of apply qa
- Connect to register-qa postgres using debug: `bash -x scripts/konduit.sh  register-qa -- psql`
- Write down the value of ORIG_URL
- Connect to register qa postgres using apply qa app: `scripts/konduit.sh -u <URL> apply-qa -- psql`

### Override redis database server of apply qa
- Connect to register-qa cache redis using debug: `bash -x scripts/konduit.sh -r REDIS_CACHE_URL register-qa -- redis-cli `
- Write down the value of ORIG_URL
- Connect to register qa cache redis using apply qa app: `scripts/konduit.sh -u <URL> apply-qa -- redis-cli`

### Test with review apps
They use container backed postgres and redis. The above protocol can be used too.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
