### PR TITLE
Add workload identity federation to TRA namespaces

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -13,7 +13,8 @@
     "tech-arch-production"
   ],
   "gcp_wif_namespaces": [
-    "bat-production"
+    "bat-production",
+    "tra-production"
   ],
   "cluster_kv": "s189p01-tsc-pd-kv",
   "statuscake_alerts": {

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -20,7 +20,9 @@
   ],
   "gcp_wif_namespaces": [
     "bat-qa",
-    "bat-staging"
+    "bat-staging",
+    "tra-development",
+    "tra-test"
   ],
   "cluster_kv": "s189t01-tsc-ts-kv",
   "ingress_cert_name": "test-teacherservices-cloud-2",


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
WIF is live in the BAT apps. We can start migrating TRA apps now, especially TRS as it's the first dotnet app.

## Changes proposed in this pull request
Add Google WIF to all TRA namespaces


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
