### PR TITLE
OOMKilled query fixed on global and namespace dashboards

### DIFF
--- a/cluster/terraform_kubernetes/config/dashboards/k8s-views-global.json
+++ b/cluster/terraform_kubernetes/config/dashboards/k8s-views-global.json
@@ -2097,7 +2097,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(increase(container_oom_events_total{cluster=\"$cluster\"}[5m])) by (namespace) > 0",
+          "expr": "(\nkube_pod_container_status_restarts_total{ container!=\"\", cluster=\"$cluster\"} - kube_pod_container_status_restarts_total {container!=\"\", cluster=\"$cluster\"} offset 5m >= 1\n)\nand ignoring (reason)\nmin_over_time(kube_pod_container_status_last_terminated_reason{ container!=\"\", cluster=\"$cluster\",reason=\"OOMKilled\"}[5m]) == 1",
           "interval": "",
           "legendFormat": "{{ namespace }}",
           "range": true,

--- a/cluster/terraform_kubernetes/config/dashboards/k8s-views-namespaces.json
+++ b/cluster/terraform_kubernetes/config/dashboards/k8s-views-namespaces.json
@@ -1291,7 +1291,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(increase(container_oom_events_total{namespace=~\"${namespace}\", cluster=\"$cluster\"}[5m])) by (namespace, pod) > 0",
+          "expr": "(\nkube_pod_container_status_restarts_total{namespace=~\"${namespace}\",  container!=\"\", cluster=\"$cluster\"} - kube_pod_container_status_restarts_total {namespace=~\"${namespace}\",  container!=\"\", cluster=\"$cluster\"} offset 5m >= 1\n)\nand ignoring (reason)\nmin_over_time(kube_pod_container_status_last_terminated_reason{namespace=~\"${namespace}\", container!=\"\", cluster=\"$cluster\",reason=\"OOMKilled\"}[5m]) == 1",
           "interval": "",
           "legendFormat": "namespace: {{ namespace }} - pod: {{ pod }}",
           "range": true,


### PR DESCRIPTION
## Context
OOMKilled dashboard query fix

## Changes proposed in this pull request
 Update dashboards global and namespace , used metric kube_pod_container_status_restarts_total

## Guidance to review
  Verrify OOM Killed events in Gloabla and namespace dashbaords
## Before merging
NA

## After merging
NA
## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
