### PR TITLE
Added annotation to block metric enpoint

### DIFF
--- a/cluster/terraform_kubernetes/config/development.tfvars.json
+++ b/cluster/terraform_kubernetes/config/development.tfvars.json
@@ -16,5 +16,6 @@
   "thanos_retention_raw": "3d",
   "thanos_retention_5m": "3d",
   "thanos_retention_1h": "3d",
-  "cluster_short": "dv"
+  "cluster_short": "dv",
+  "block_metrics_endpoint" : false
 }

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -81,5 +81,6 @@
     "SLACK_WEBHOOK_ITTMS",
     "SLACK_WEBHOOK_PTT",
     "SLACK_WEBHOOK_GENERIC"
-  ]
+  ],
+  "block_metrics_endpoint" : false
 }

--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -143,7 +143,20 @@ resource "helm_release" "ingress-nginx" {
     value = "nginx"
     type  = "string"
   }
+  # Block access to /metrics endpoint
+  dynamic "set" {
+    for_each = var.block_metrics_endpoint ? [1] : []
 
+    content {
+      name  = "controller.config.server-snippet"
+      value = <<-EOT
+        location /metrics {
+            deny all;
+        }
+      EOT
+      type  = "string"
+    }
+  }
 }
 
 resource "helm_release" "ingress-nginx-clone" {

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -190,6 +190,12 @@ variable "alertable_apps" {
   default     = {}
 }
 
+variable "block_metrics_endpoint" {
+  description = "Block metric endpoints"
+  default     = true
+  type        = bool
+}
+
 locals {
   cluster_name = (
     var.cip_tenant ?


### PR DESCRIPTION
## Context
Block  metric endpoints for all production services.

## Changes proposed in this pull request
Added annotation to block metrics endpoint.

## Guidance to review
After deploying ,  metric  endpoint should not be  accessible  to  any service.

Testing done on dev cluster2 https://apply-review-2222.cluster2.development.teacherservices.cloud/metrics

## Before merging

Terraform plan :

      + set {
          + name  = "controller.config.server-snippet"
          + type  = "string"
          + value = <<-EOT
                location /metrics {
                    deny all;
                }
            EOT
        }

## After merging
 
## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
