### PR TITLE
Increase minimum node for app1 nodepool

### DIFF
--- a/cluster/terraform_aks_cluster/config/development.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/development.tfvars.json
@@ -7,7 +7,7 @@
   },
   "node_pools": {
     "apps1": {
-      "min_count": 1,
+      "min_count": 3,
       "max_count": 4,
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"


### PR DESCRIPTION

## Context
We are running into issues during the deployments post AKS cluster deployment due to enough nodes not being in a ready state.

## Changes proposed in this pull request
Increase the minimum number of nodes for apps1 nodepool within the development.tfvars for the AKS cluster deployment to 3.

## Guidance to review
Ensure deployment of K8s cluster for development cluster doesn’t have the same issues logged in https://trello.com/c/le9lI9EQ/1981-increase-minimum-nodes-for-app1-nodepool-aks-terraform-development and has a clean run the first time.



## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
