### PR TITLE
Thanos memory increases

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -39,7 +39,7 @@
   "prometheus_app_cpu": "0.5",
   "thanos_querier_mem": "2Gi",
   "thanos_app_cpu": "0.5",
-  "thanos_compactor_mem": "6Gi",
+  "thanos_compactor_mem": "7Gi",
   "thanos_store_mem": "3Gi",
   "cluster_short": "pd",
   "alertmanager_slack_receiver_list": [

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -45,7 +45,7 @@
   "prometheus_app_mem": "12Gi",
   "prometheus_app_cpu": "0.5",
   "thanos_querier_mem": "2Gi",
-  "thanos_store_mem": "4Gi",
+  "thanos_store_mem": "5Gi",
   "thanos_compactor_mem": "6Gi",
   "thanos_app_cpu": "0.5",
   "cluster_short": "ts",


### PR DESCRIPTION
## Context
https://trello.com/c/rPsNKgib/1989-monitoring-increase-thanos-memory
Some thanos pods are failing with OOM

## Changes proposed in this pull request
Increase memory from 4Gi to 5Gi for thanos-store-gateway in test
Increase memory from 6Gi to 7Gi for thanos-compactor in prod

## Guidance to review
make env terraform-plan
kubectl -n monitoring get pods (to see restarts)

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
