### PR TITLE
Update memory and liveness probe for thanos-store

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -40,7 +40,7 @@
   "thanos_querier_mem": "2Gi",
   "thanos_app_cpu": "0.5",
   "thanos_compactor_mem": "7Gi",
-  "thanos_store_mem": "3Gi",
+  "thanos_store_mem": "5Gi",
   "cluster_short": "pd",
   "alertmanager_slack_receiver_list": [
     "SLACK_WEBHOOK_ATT",

--- a/cluster/terraform_kubernetes/thanos.tf
+++ b/cluster/terraform_kubernetes/thanos.tf
@@ -206,6 +206,9 @@ resource "kubernetes_deployment" "thanos-store-gateway" {
               path = "/-/healthy"
               port = "http"
             }
+            failure_threshold = 10
+            period_seconds    = 10
+            timeout_seconds   = 5
           }
 
           readiness_probe {


### PR DESCRIPTION
## Context
thanos-store-gateway not running
- it was failing the liveness probe so increased probe settings
- once probe increased it was failing with OOM

## Changes proposed in this pull request
Increase liveness probe interval and memory

## Guidance to review
make production terraform-plan

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
