### PR TITLE
Added security context fixes

### DIFF
--- a/cluster/terraform_aks_cluster/.terraform.lock.hcl
+++ b/cluster/terraform_aks_cluster/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "3.116.0"
   hashes = [
     "h1:2QbjtN4oMXzdA++Nvrj/wSmWZTPgXKOSFGGQCLEMrb4=",
+    "h1:BCR3NIorFSvGG3v/+JOiiw3VM4PkChLO4m84wzD9NDo=",
     "zh:02b6606aff025fc2a962b3e568e000300abe959adac987183c24dac8eb057f4d",
     "zh:2a23a8ce24ff9e885925ffee0c3ea7eadba7a702541d05869275778aa47bdea7",
     "zh:57d10746384baeca4d5c56e88872727cdc150f437b8c5e14f0542127f7475e24",

--- a/cluster/terraform_kubernetes/.terraform.lock.hcl
+++ b/cluster/terraform_kubernetes/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/eppo/environment" {
   constraints = "1.3.5"
   hashes = [
     "h1:1Af95/IhzW16rbX8kSApfrAi8vwc5+7uVbCeyVaGw2E=",
+    "h1:pceowuRAKcjLd+g4noIJdX6CBIWavlM4BvRTsGfH0uQ=",
     "zh:00e7a6bf7f0f09cc4871d7f4fee2c943ce61c05b9802365a97703d6c2e63e3dc",
     "zh:018d92e621177d053ed5c32e8220efa8c019852c4d60cc7539683bac28470d9b",
     "zh:12ca5162286b80b7f46bd013ae2007641132d201af12bc6adb872f9a0ff85b7a",
@@ -29,6 +30,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "3.116.0"
   hashes = [
     "h1:2QbjtN4oMXzdA++Nvrj/wSmWZTPgXKOSFGGQCLEMrb4=",
+    "h1:BCR3NIorFSvGG3v/+JOiiw3VM4PkChLO4m84wzD9NDo=",
     "zh:02b6606aff025fc2a962b3e568e000300abe959adac987183c24dac8eb057f4d",
     "zh:2a23a8ce24ff9e885925ffee0c3ea7eadba7a702541d05869275778aa47bdea7",
     "zh:57d10746384baeca4d5c56e88872727cdc150f437b8c5e14f0542127f7475e24",
@@ -48,6 +50,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   version     = "2.15.0"
   constraints = "2.15.0"
   hashes = [
+    "h1:VymvscRkDy0+zN2uKpKYY6njXPY8JROARuaL3VPsEos=",
     "h1:qPUoXPUCizzPS8tlJydH+VBXeiOeizOiSEOaNqZEyMY=",
     "zh:18b94c7c83c30ad166722a61a412e3de6a67935772960e79aaa24c15f8ea0d0f",
     "zh:4f07c929a71e8169f7471b7600bfcca36dfb295787e975e82ac0455a3ab68b47",
@@ -68,6 +71,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.32.0"
   constraints = "2.32.0"
   hashes = [
+    "h1:3j4XBR5UWQA7xXaiEnzZp0bHbcwOhWetHYKTWIrUTI0=",
     "h1:Cj3RHyw3wE3AkNlCtSNrZfjFNkShvaZR0K/K3pJlYJU=",
     "zh:0e715d7fb13a8ad569a5fdc937b488590633f6942e986196fdb17cd7b8f7720e",
     "zh:495fc23acfe508ed981e60af9a3758218b0967993065e10a297fdbc210874974",
@@ -88,6 +92,7 @@ provider "registry.terraform.io/statuscakedev/statuscake" {
   version     = "2.2.2"
   constraints = "2.2.2"
   hashes = [
+    "h1:nVaJkDBk4sv0yWFzg3p+yeJGzE8mB4KJv3Q6/UgU164=",
     "h1:wFoZJfmNvG6XTf65NLai67geSHqYV1Tilx7OITrHilE=",
     "zh:0916313344c579d6e05d70f88129a10fe48f7dabe0e61cad17874d6c496f288d",
     "zh:0d491ff72c2eda6482855033ca2146c5ace1663d07cb3da7253b59ed2e2ec6f4",

--- a/cluster/terraform_kubernetes/grafana.tf
+++ b/cluster/terraform_kubernetes/grafana.tf
@@ -50,6 +50,20 @@ resource "kubernetes_deployment" "grafana_deployment" {
         container {
           name  = "grafana"
           image = "grafana/grafana:${var.grafana_version}"
+          security_context {
+            run_as_user  = 1000
+            run_as_group = 3000
+            capabilities {
+              drop = ["ALL"]
+            }
+            allow_privilege_escalation = false
+            privileged                 = false
+            run_as_non_root            = true
+            read_only_root_filesystem  = true
+            seccomp_profile {
+              type = "RuntimeDefault"
+            }
+          }
           port {
             container_port = 3000
           }

--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -157,30 +157,53 @@ resource "helm_release" "ingress-nginx" {
       type  = "string"
     }
   }
-}
 
-resource "helm_release" "ingress-nginx-clone" {
-  count    = var.clone_cluster ? 1 : 0
-  provider = helm.clone
+  set {
+    name  = "controller.podSecurityContext.runAsUser"
+    value = "1000"
+    type  = "auto"
+  }
+  set {
+    name  = "controller.podSecurityContext.runAsGroup"
+    value = "3000"
+    type  = "auto"
+  }
+  set {
+    name  = "controller.securityContext.capabilities.drop[0]"
+    value = "ALL"
+    type  = "string"
+  }
+  // By default, NET_BIND_SERVICE is added to the deployment by the Helm chart, even if we do not explicitly set it.
 
-  name       = helm_release.ingress-nginx.name
-  repository = helm_release.ingress-nginx.repository
-  chart      = helm_release.ingress-nginx.chart
-  version    = helm_release.ingress-nginx.version
-
-  dynamic "set" {
-    # Exclude the load balancer IP to force clone to use dynamic Public IP for load balancer ingress
-    for_each = [
-      for s in helm_release.ingress-nginx.set : s
-      if s.name != "controller.service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-ipv4"
-      && s.name != "controller.service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-resource-group"
-    ]
-
-    content {
-      name  = set.value["name"]
-      value = set.value["value"]
-      type  = set.value["type"]
-    }
+  set {
+    name  = "controller.securityContext.allowPrivilegeEscalation"
+    value = "false"
+    type  = "string"
+  }
+  set {
+    name  = "controller.securityContext.privileged"
+    value = "false"
+    type  = "string"
+  }
+  set {
+    name  = "controller.securityContext.runAsNonRoot"
+    value = "true"
+    type  = "string"
+  }
+  set {
+    name  = "controller.securityContext.readOnlyRootFilesystem"
+    value = "true"
+    type  = "string"
+  }
+  set {
+    name  = "controller.securityContext.seccompProfile.type"
+    value = "RuntimeDefault"
+    type  = "string"
+  }
+  set {
+    name  = "controller.automountServiceAccountToken"
+    value = "false"
+    type  = "string"
   }
 }
 

--- a/cluster/terraform_kubernetes/prometheus.tf
+++ b/cluster/terraform_kubernetes/prometheus.tf
@@ -90,6 +90,21 @@ resource "kubernetes_deployment" "prometheus" {
           image = "prom/prometheus:${var.prometheus_version}"
           name  = "prometheus"
 
+          security_context {
+            run_as_user  = 1000
+            run_as_group = 3000
+            capabilities {
+              drop = ["ALL"]
+            }
+            allow_privilege_escalation = false
+            privileged                 = false
+            run_as_non_root            = true
+            read_only_root_filesystem  = true
+            seccomp_profile {
+              type = "RuntimeDefault"
+            }
+          }
+
           args = [
             "--storage.tsdb.retention.time=${var.prometheus_tsdb_retention_time}",
             "--config.file=/etc/prometheus/prometheus.yml",

--- a/cluster/terraform_kubernetes/thanos.tf
+++ b/cluster/terraform_kubernetes/thanos.tf
@@ -80,6 +80,20 @@ resource "kubernetes_deployment" "thanos-querier" {
         container {
           image = "quay.io/thanos/thanos:${var.thanos_version}"
           name  = "thanos-querier"
+          security_context {
+            run_as_user  = 1000
+            run_as_group = 3000
+            capabilities {
+              drop = ["ALL"]
+            }
+            allow_privilege_escalation = false
+            privileged                 = false
+            run_as_non_root            = true
+            read_only_root_filesystem  = true
+            seccomp_profile {
+              type = "RuntimeDefault"
+            }
+          }
 
           args = [
             "query",
@@ -181,6 +195,20 @@ resource "kubernetes_deployment" "thanos-store-gateway" {
         container {
           image = "quay.io/thanos/thanos:${var.thanos_version}"
           name  = "thanos-store-gateway"
+          security_context {
+            run_as_user  = 1000
+            run_as_group = 3000
+            capabilities {
+              drop = ["ALL"]
+            }
+            allow_privilege_escalation = false
+            privileged                 = false
+            run_as_non_root            = true
+            read_only_root_filesystem  = true
+            seccomp_profile {
+              type = "RuntimeDefault"
+            }
+          }
 
           args = [
             "store",
@@ -234,6 +262,11 @@ resource "kubernetes_deployment" "thanos-store-gateway" {
             name       = "thanos-config-volume"
             read_only  = true
           }
+
+          volume_mount {
+            mount_path = "/data" # Mounting the /data directory to a writable volume
+            name       = "thanos-data-volume"
+          }
         }
 
         volume {
@@ -241,6 +274,11 @@ resource "kubernetes_deployment" "thanos-store-gateway" {
           secret {
             secret_name = "thanos-objstore-config"
           }
+        }
+
+        volume {
+          name = "thanos-data-volume"
+          empty_dir {}
         }
 
       }
@@ -276,6 +314,21 @@ resource "kubernetes_deployment" "thanos-compactor" {
         container {
           image = "quay.io/thanos/thanos:${var.thanos_version}"
           name  = "thanos-compactor"
+
+          security_context {
+            run_as_user  = 1000
+            run_as_group = 3000
+            capabilities {
+              drop = ["ALL"]
+            }
+            allow_privilege_escalation = false
+            privileged                 = false
+            run_as_non_root            = true
+            read_only_root_filesystem  = true
+            seccomp_profile {
+              type = "RuntimeDefault"
+            }
+          }
 
           args = [
             "compact",
@@ -323,6 +376,11 @@ resource "kubernetes_deployment" "thanos-compactor" {
             name       = "thanos-config-volume"
             read_only  = true
           }
+
+          volume_mount {
+            mount_path = "/data" # Mounting the /data directory to a writable volume
+            name       = "thanos-data-volume"
+          }
         }
 
         volume {
@@ -330,6 +388,11 @@ resource "kubernetes_deployment" "thanos-compactor" {
           secret {
             secret_name = "thanos-objstore-config"
           }
+        }
+
+        volume {
+          name = "thanos-data-volume"
+          empty_dir {}
         }
 
       }

--- a/cluster/terraform_kubernetes/welcome_app.tf
+++ b/cluster/terraform_kubernetes/welcome_app.tf
@@ -21,6 +21,7 @@ resource "kubernetes_deployment" "welcome_app" {
         }
       }
       spec {
+        automount_service_account_token = false
         node_selector = {
           "teacherservices.cloud/node_pool" = "applications"
           "kubernetes.io/os"                = "linux"
@@ -48,7 +49,22 @@ resource "kubernetes_deployment" "welcome_app" {
 
         container {
           name  = local.welcome_app_name
-          image = "nginx"
+          image = "nginxinc/nginx-unprivileged:1.26.1"
+
+          security_context {
+            run_as_user  = 1000
+            run_as_group = 3000
+            capabilities {
+              drop = ["ALL"]
+            }
+            allow_privilege_escalation = false
+            privileged                 = false
+            run_as_non_root            = true
+            read_only_root_filesystem  = true
+            seccomp_profile {
+              type = "RuntimeDefault"
+            }
+          }
 
           resources {
             requests = {
@@ -60,14 +76,51 @@ resource "kubernetes_deployment" "welcome_app" {
               memory = "64M"
             }
           }
+
           port {
             container_port = 80
           }
+
+          # Mount the updated NGINX configuration from the ConfigMap
+          volume_mount {
+            name       = "nginx-config-volume"
+            mount_path = "/etc/nginx/conf.d/default.conf"
+            sub_path   = "default.conf"
+          }
+
+          # Mount a writable volume to /tmp
+          volume_mount {
+            name       = "nginx-tmp"
+            mount_path = "/tmp"
+          }
+          volume_mount {
+            name       = "nginx-cache"
+            mount_path = "/var/cache/nginx"
+          }
+        }
+
+        volume {
+          name = "nginx-config-volume"
+          config_map {
+            name = kubernetes_config_map.welcome_app_nginx_config.metadata[0].name
+          }
+        }
+
+        volume {
+          name = "nginx-tmp"
+          empty_dir {}
+        }
+
+        volume {
+          name = "nginx-cache"
+          empty_dir {}
         }
       }
     }
   }
 }
+
+
 
 
 resource "kubernetes_service" "welcome_app" {
@@ -79,7 +132,7 @@ resource "kubernetes_service" "welcome_app" {
     type = "ClusterIP"
     port {
       port        = 80
-      target_port = 80
+      target_port = 8080
     }
     selector = {
       app = local.welcome_app_name
@@ -112,5 +165,31 @@ resource "kubernetes_ingress_v1" "welcome_app" {
         }
       }
     }
+  }
+}
+
+resource "kubernetes_config_map" "welcome_app_nginx_config" {
+  metadata {
+    name      = "nginx-config"
+    namespace = kubernetes_namespace.default_list[local.welcome_app_namespace].metadata[0].name
+  }
+
+  data = {
+    "default.conf" = <<EOT
+server {
+    listen       8080;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}
+EOT
   }
 }


### PR DESCRIPTION
## Context
Added security context  fixes to welcome app , ingress , prometheus ,thanos and grafana

## Changes proposed in this pull request.

Added security_context  to container with following attributes.

`
  security_context {
            run_as_user  = 1000
            run_as_group = 3000
            capabilities {
              add  = ["NET_BIND_SERVICE"]
              drop = ["ALL"]
            }
            allow_privilege_escalation = false
            privileged                 = false
            run_as_non_root            = true
            read_only_root_filesystem  = true
            seccomp_profile {
              type = "RuntimeDefault"
            }
          }
`
 
## Guidance to review
Deployed on cluster2 , this can be tested.
https://www.cluster2.development.teacherservices.cloud/
https://prometheus.cluster2.development.teacherservices.cloud/
https://thanos.cluster2.development.teacherservices.cloud/
https://grafana.cluster2.development.teacherservices.cloud/
https://register-2222.cluster2.development.teacherservices.cloud/

## Before merging
Need to apply all environments before merge.

## After merging
Check all pipelines are success.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
