### PR TITLE
Upgrade the ingress controller version for dev, plaftform-test and test environments

### DIFF
--- a/cluster/terraform_kubernetes/config/development.tfvars.json
+++ b/cluster/terraform_kubernetes/config/development.tfvars.json
@@ -12,7 +12,7 @@
   "cluster_dns_resource_group_name": "s189d01-tscdomains-rg",
   "cluster_dns_zone": "development.teacherservices.cloud",
   "cluster_kv": "s189d01-tsc2-dv-kv",
-  "ingress_nginx_version": "4.8.3",
+  "ingress_nginx_version": "4.11.0",
   "thanos_retention_raw": "3d",
   "thanos_retention_5m": "3d",
   "thanos_retention_1h": "3d",

--- a/cluster/terraform_kubernetes/config/platform-test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/platform-test.tfvars.json
@@ -20,7 +20,7 @@
       ]
     }
   },
-  "ingress_nginx_version": "4.8.3",
+  "ingress_nginx_version": "4.11.0",
   "thanos_retention_raw": "3d",
   "thanos_retention_5m": "3d",
   "thanos_retention_1h": "3d",

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -38,7 +38,7 @@
       ]
     }
   },
-  "ingress_nginx_version": "4.8.3",
+  "ingress_nginx_version": "4.11.0",
   "enable_lowpriority_app": true,
   "lowpriority_app_cpu": "0.5",
   "lowpriority_app_mem": "1Gi",


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
We use [version 4.8.3](https://github.com/DFE-Digital/teacher-services-cloud/blob/18482f44ee47d1738e2cb151610d2da5c266071d/cluster/terraform_kubernetes/config/production.tfvars.json#L34). The latest version is [4.11.](https://github.com/kubernetes/ingress-nginx/releases)0. We should not fall behind as it is a critical component and it may be tied to the kubernetes version.

## Changes proposed in this pull request
Upgrade ingress controller version to 4.11.0


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
