### PR TITLE
Upgrade the ingress controller version for prod

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -33,7 +33,7 @@
     "platform-test.teacherservices.cloud",
     "development.teacherservices.cloud"
   ],
-  "ingress_nginx_version": "4.8.3",
+  "ingress_nginx_version": "4.11.0",
   "enable_lowpriority_app": true,
   "prometheus_app_mem": "16Gi",
   "prometheus_app_cpu": "0.5",


### PR DESCRIPTION
## Context
We use [version 4.8.3](https://github.com/DFE-Digital/teacher-services-cloud/blob/18482f44ee47d1738e2cb151610d2da5c266071d/cluster/terraform_kubernetes/config/production.tfvars.json#L34). The latest version is [4.11.](https://github.com/kubernetes/ingress-nginx/releases)0. We should not fall behind as it is a critical component and it may be tied to the kubernetes version.

## Changes proposed in this pull request
Update ingress controller version to 4.11.0 for production


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
