### PR TITLE
Version Upgrade for monitoring components

### DIFF
--- a/cluster/terraform_kubernetes/config/development.tfvars.json
+++ b/cluster/terraform_kubernetes/config/development.tfvars.json
@@ -14,8 +14,8 @@
   "cluster_kv": "s189d01-tsc2-dv-kv",
   "ingress_nginx_version": "4.11.0",
   "thanos_retention_raw": "3d",
-  "thanos_retention_5m": "3d",
-  "thanos_retention_1h": "3d",
+  "thanos_retention_5m": "10d",
+  "thanos_retention_1h": "12d",
   "cluster_short": "dv",
   "block_metrics_endpoint" : false
 }

--- a/cluster/terraform_kubernetes/config/platform-test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/platform-test.tfvars.json
@@ -22,8 +22,8 @@
   },
   "ingress_nginx_version": "4.11.0",
   "thanos_retention_raw": "3d",
-  "thanos_retention_5m": "3d",
-  "thanos_retention_1h": "3d",
+  "thanos_retention_5m": "10d",
+  "thanos_retention_1h": "12d",
   "cluster_short": "pt",
   "alertmanager_slack_receiver_list": [],
   "alertable_apps": {}

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -70,7 +70,7 @@ variable "grafana_limit_mem" {
 }
 
 variable "grafana_version" {
-  default = "10.3.3"
+  default = "11.1.5"
 }
 
 variable "lowpriority_app_cpu" {
@@ -86,7 +86,7 @@ variable "lowpriority_app_replicas" {
 }
 
 variable "kube_state_metrics_version" {
-  default = "2.10.1"
+  default = "2.12.0"
 }
 
 data "azurerm_client_config" "current" {}
@@ -96,7 +96,7 @@ data "environment_variables" "github_actions" {
 }
 
 variable "prometheus_version" {
-  default = "v2.49.1"
+  default = "v2.54.1"
 }
 
 variable "prometheus_tsdb_retention_time" {
@@ -115,7 +115,7 @@ variable "prometheus_app_cpu" {
 }
 
 variable "thanos_version" {
-  default = "v0.8.0"
+  default = "v0.36.1"
 }
 
 variable "thanos_app_mem" {
@@ -163,7 +163,7 @@ variable "cluster_short" {
 }
 
 variable "alertmanager_image_version" {
-  default = "v0.19.0"
+  default = "v0.27.0"
 }
 
 variable "alertmanager_app_cpu" {
@@ -174,7 +174,7 @@ variable "alertmanager_app_mem" {
   default = "1Gi"
 }
 variable "node_exporter_version" {
-  default = "v1.7.0"
+  default = "v1.8.2"
 }
 variable "filebeat_version" {
   default = "8.12.2"


### PR DESCRIPTION
## Context
Upgrade monitoring  components to latest version
## Changes proposed in this pull request.

Upgraded to following versions.

          prometheus v2.54.1 
          alertmanager v0.27.0 
          thanos v0.36.1 
          grafana 11.1.5 
          node exporter v1.8.2 
          kube state metrics: 2.12.0 ( AKS 1.29)


## Guidance to review
Deployed on cluster2 all metrics are coming.

Grafna features : https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v11-0/

 
## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
