### PR TITLE
Revert ingress  ngnix version to 4.8.3

### DIFF
--- a/cluster/terraform_kubernetes/config/development.tfvars.json
+++ b/cluster/terraform_kubernetes/config/development.tfvars.json
@@ -12,7 +12,7 @@
   "cluster_dns_resource_group_name": "s189d01-tscdomains-rg",
   "cluster_dns_zone": "development.teacherservices.cloud",
   "cluster_kv": "s189d01-tsc2-dv-kv",
-  "ingress_nginx_version": "4.11.0",
+  "ingress_nginx_version": "4.8.3",
   "thanos_retention_raw": "3d",
   "thanos_retention_5m": "3d",
   "thanos_retention_1h": "3d",

--- a/cluster/terraform_kubernetes/config/platform-test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/platform-test.tfvars.json
@@ -20,7 +20,7 @@
       ]
     }
   },
-  "ingress_nginx_version": "4.11.0",
+  "ingress_nginx_version": "4.8.3",
   "thanos_retention_raw": "3d",
   "thanos_retention_5m": "3d",
   "thanos_retention_1h": "3d",

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -38,7 +38,7 @@
       ]
     }
   },
-  "ingress_nginx_version": "4.11.0",
+  "ingress_nginx_version": "4.8.3",
   "enable_lowpriority_app": true,
   "lowpriority_app_cpu": "0.5",
   "lowpriority_app_mem": "1Gi",


### PR DESCRIPTION
## Context
<!-- Why are we making this change? New feature? Bug fix? -->

## Changes proposed in this pull request
      Revert ingress  ngnix version to 4.8.3

## Guidance to review
      Revert ingress  ngnix version to 4.8.3

https://grafana.test.teacherservices.cloud/d/nginx/nginx-ingress-controller?orgId=1&refresh=10m

https://grafana.platform-test.teacherservices.cloud/d/nginx/nginx-ingress-controller?orgId=1&refresh=10m

 
## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
