### PR TITLE
[1919] Upgrade ingress controller to 4.11.0 with metrics enabled

### DIFF
--- a/cluster/terraform_kubernetes/config/development.tfvars.json
+++ b/cluster/terraform_kubernetes/config/development.tfvars.json
@@ -12,7 +12,7 @@
   "cluster_dns_resource_group_name": "s189d01-tscdomains-rg",
   "cluster_dns_zone": "development.teacherservices.cloud",
   "cluster_kv": "s189d01-tsc2-dv-kv",
-  "ingress_nginx_version": "4.8.3",
+  "ingress_nginx_version": "4.11.0",
   "thanos_retention_raw": "3d",
   "thanos_retention_5m": "3d",
   "thanos_retention_1h": "3d",

--- a/cluster/terraform_kubernetes/config/platform-test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/platform-test.tfvars.json
@@ -20,7 +20,7 @@
       ]
     }
   },
-  "ingress_nginx_version": "4.8.3",
+  "ingress_nginx_version": "4.11.0",
   "thanos_retention_raw": "3d",
   "thanos_retention_5m": "3d",
   "thanos_retention_1h": "3d",

--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -33,7 +33,7 @@
     "platform-test.teacherservices.cloud",
     "development.teacherservices.cloud"
   ],
-  "ingress_nginx_version": "4.8.3",
+  "ingress_nginx_version": "4.11.0",
   "enable_lowpriority_app": true,
   "prometheus_app_mem": "16Gi",
   "prometheus_app_cpu": "0.5",

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -38,7 +38,7 @@
       ]
     }
   },
-  "ingress_nginx_version": "4.8.3",
+  "ingress_nginx_version": "4.11.0",
   "enable_lowpriority_app": true,
   "lowpriority_app_cpu": "0.5",
   "lowpriority_app_mem": "1Gi",

--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -106,9 +106,12 @@ resource "helm_release" "ingress-nginx" {
     type  = "string"
   }
 
-  # Annotations to enable scraping for ingress controller
-  # where podAnnotations is the top level property, port is ingress controller port for metrics,
-  # path is default path for metrics used throughout, enabled is true if scraping is desired
+  # Enable prometheus metrics and configure scraping
+  set {
+    name  = "controller.metrics.enabled"
+    value = "true"
+    type  = "auto"
+  }
   set {
     name  = "controller.podAnnotations.prometheus\\.io/scrape"
     value = "true"


### PR DESCRIPTION
## Context
The upgrade was reverted as the dashboard was empty. We still want to upgrade, with a working dashboard.

## Changes proposed in this pull request
Expose ingress controller prometheus metrics. It must be required explicitly in the 4.11.0 version.

## Guidance to review
- Working dashboard: https://grafana.cluster1.development.teacherservices.cloud/d/nginx/nginx-ingress-controller?orgId=1&refresh=10m&editIndex=1&from=now-5m&to=now
- Example of nginx metrics: https://prometheus.cluster1.development.teacherservices.cloud/graph?g0.expr=nginx_ingress_controller_requests&g0.tab=1&g0.display_mode=lines&g0.show_exemplars=0&g0.range_input=1h

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
