### PR TITLE
updating aks version for production to 1.29.7

### DIFF
--- a/cluster/terraform_aks_cluster/config/production.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/production.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.28.9",
+  "kubernetes_version": "1.29.7",
   "default_node_pool": {
     "node_count": 3,
-    "orchestrator_version": "1.28.9"
+    "orchestrator_version": "1.29.7"
   },
   "node_pools": {
     "apps1": {
@@ -13,7 +13,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.28.9"
+      "orchestrator_version": "1.29.7"
     }
   },
   "admin_group_id": "5b0f84de-54a8-481a-8689-f3c226597259",


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context

Upgrading production for AKS nodes to 1.29.7

## Changes proposed in this pull request

Upgrading production for AKS nodes to 1.29.7

## Guidance to review

Check pods are all healthy in production cluster and running. Validate domains are still valid.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
