### PR TITLE
Add grafana dashboard check step after upgrades

### DIFF
--- a/documentation/Ingress-controller-upgrade.md
+++ b/documentation/Ingress-controller-upgrade.md
@@ -35,5 +35,6 @@ make test terraform-apply CONFIRM_TEST=yes
 
 
         ```
+- After successful upgrades for each environment, check metrics are still displaying and working well in Grafana dashboards: https://grafana.cluster<x\>.development.teacherservices.cloud, https://grafana.platform-test.teacherservices.cloud, https://grafana.test.teacherservices.cloud, https://grafana.teacherservices.cloud
 - Follow the same process for production and raise a PR for each environment.
 - Wait at least 24 hours before applying upgrade to production (if any downtime was obversed during deployment(s) to lower environment(s), notify the application teams before production upgrade).

--- a/documentation/aks-upgrade.md
+++ b/documentation/aks-upgrade.md
@@ -97,6 +97,8 @@ az aks nodepool get-upgrades --resource-group <ResourceGroup> --cluster-name <Cl
     - Run following commands in another terminal to see the cluster upgrade progress.
         -  kubectl get events --watch
         -  kubectl get nodes --watch
+1. After successful upgrades for each environment, check metrics are still displaying and working well in Grafana
+    - Check the dashboards in grafana: https://grafana.cluster<x\>.development.teacherservices.cloud, https://grafana.platform-test.teacherservices.cloud, https://grafana.test.teacherservices.cloud, https://grafana.teacherservices.cloud
 1. Follow the same manual process to upgrade the platform_test cluster
     - Test with the welcome app: https://www.platform-test.teacherservices.cloud/
     - Raise PR


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
Upgrades to AKS or ingress-controller may break the metrics and Grafana dashboards.

## Changes proposed in this pull request
Add a step to check dashboards in:

[teacher-services-cloud/documentation/aks-upgrade.md at main · DFE-Digital/teacher-services-cloud](https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/aks-upgrade.md)

[teacher-services-cloud/documentation/Ingress-controller-upgrade.md at main · DFE-Digital/teacher-services-cloud](https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/Ingress-controller-upgrade.md)

## Guidance to review
Review the additional step in the documentation


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
