### PR TITLE
Set container uid,gid for thanos monitoring

### DIFF
--- a/cluster/terraform_kubernetes/prometheus.tf
+++ b/cluster/terraform_kubernetes/prometheus.tf
@@ -91,8 +91,8 @@ resource "kubernetes_deployment" "prometheus" {
           name  = "prometheus"
 
           security_context {
-            run_as_user  = 1000
-            run_as_group = 3000
+            run_as_user  = 1001
+            run_as_group = 1001
             capabilities {
               drop = ["ALL"]
             }

--- a/cluster/terraform_kubernetes/thanos.tf
+++ b/cluster/terraform_kubernetes/thanos.tf
@@ -81,8 +81,8 @@ resource "kubernetes_deployment" "thanos-querier" {
           image = "quay.io/thanos/thanos:${var.thanos_version}"
           name  = "thanos-querier"
           security_context {
-            run_as_user  = 1000
-            run_as_group = 3000
+            run_as_user  = 1001
+            run_as_group = 1001
             capabilities {
               drop = ["ALL"]
             }
@@ -196,8 +196,8 @@ resource "kubernetes_deployment" "thanos-store-gateway" {
           image = "quay.io/thanos/thanos:${var.thanos_version}"
           name  = "thanos-store-gateway"
           security_context {
-            run_as_user  = 1000
-            run_as_group = 3000
+            run_as_user  = 1001
+            run_as_group = 1001
             capabilities {
               drop = ["ALL"]
             }
@@ -316,8 +316,8 @@ resource "kubernetes_deployment" "thanos-compactor" {
           name  = "thanos-compactor"
 
           security_context {
-            run_as_user  = 1000
-            run_as_group = 3000
+            run_as_user  = 1001
+            run_as_group = 1001
             capabilities {
               drop = ["ALL"]
             }


### PR DESCRIPTION
## Context
Monitoring data is not being transferred to azure by thanos

From the thanos container

```
ts=2024-09-23T13:23:53.020231501Z caller=sidecar.go:410 level=warn err="upload 01xxxxxxx: hard link block: hard link file chunks/000001: link /prometheus/01xxxxxxxx/chunks/000001 /prometheus/thanos/upload/01xxxxxxx/chunks/000001: operation not permitted" uploaded=0

$ ls -l /prometheus/
total 48
drwxr-xr-x    3 1000     3000          4096 Sep 24 03:00 01xxxxx
drwxr-xr-x    3 1000     3000          4096 Sep 24 05:00 01xxxxx1
drwxr-xr-x    3 1000     3000          4096 Sep 24 07:00 01xxxxx2
drwxr-xr-x    2 1000     3000          4096 Sep 24 08:01 chunks_head
-rw-r--r--    1 1000     3000         20001 Sep 24 08:11 queries.active
drwxr-x---    3 thanos   thanos        4096 Sep 12 16:06 thanos
-rw-r--r--    1 thanos   thanos          37 Sep 12 16:06 thanos.shipper.json
drwxr-xr-x    3 1000     3000          4096 Sep 24 08:00 wal
```

Looks like updating thanos was broken by [v0.32.0](https://github.com/thanos-io/thanos/releases/tag/v0.32.0) breaking Change default user id in container image from 0(root) to 1001

## Changes proposed in this pull request
Set container uid and gid to match what the thanos container is expecting (1001,1001)

## Guidance to review
- see grafana and thanos ui's for cluster5.
- check cluster5 azure storage account

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
