### PR TITLE
Enable different processor arch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ bin/terrafile
 
 # macOS files
 .DS_Store
+
+# Ignore Jetbrains IDE settings
+.idea

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ arm-deployment: set-azure-account
 		${WHAT_IF}
 
 bin/terrafile: ## Install terrafile to manage terraform modules
-	curl -sL https://github.com/coretech/terrafile/releases/download/v${TERRAFILE_VERSION}/terrafile_${TERRAFILE_VERSION}_$$(uname)_x86_64.tar.gz \
+	curl -sL https://github.com/coretech/terrafile/releases/download/v${TERRAFILE_VERSION}/terrafile_${TERRAFILE_VERSION}_$$(uname)_$$(uname -m).tar.gz \
 		| tar xz -C ./bin terrafile
 
 deploy-azure-resources: check-auto-approve arm-deployment # make dev deploy-azure-resources

--- a/templates/new_service/Makefile
+++ b/templates/new_service/Makefile
@@ -38,7 +38,7 @@ ci:
 	$(eval SKIP_CONFIRM=true)
 
 bin/terrafile: ## Install terrafile to manage terraform modules
-	curl -sL https://github.com/coretech/terrafile/releases/download/v${TERRAFILE_VERSION}/terrafile_${TERRAFILE_VERSION}_$$(uname)_x86_64.tar.gz \
+	curl -sL https://github.com/coretech/terrafile/releases/download/v${TERRAFILE_VERSION}/terrafile_${TERRAFILE_VERSION}_$$(uname)_$$(uname -m).tar.gz \
 		| tar xz -C ./bin terrafile
 
 set-azure-account:


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
<!-- Why are we making this change? New feature? Bug fix? -->
Usage of terrafile only supports x86_64 architecture and does not provide support for apple silicon arm based processors. This PR adds support for different processor architectures.

## Changes proposed in this pull request
<!-- Describe briefly the technical implementation -->
<!-- Show any dependencies between pull requests, i.e. this must be merged before or after another -->
- Update the terrafile commands in makefile to support different process architectures.
- Update the .gitignore to ignore jetbrains .idea directory 

## Guidance to review
<!-- Show how this can be tested or evidence that it is working -->
- Users on mac should now be able to use makefile and execute commands.
- Users on windows will be able to use makefile as before.

## Before merging
<!-- Any extra steps like: delete temp commit, send warning, wait after office hours... -->
N/A

## After merging
<!-- Any extra steps like: update other PR, apply manually, inform someone... -->
N/A

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
