### PR TITLE
Add github workflow templates to new_service

### DIFF
--- a/documentation/disaster-recovery-testing.md
+++ b/documentation/disaster-recovery-testing.md
@@ -12,16 +12,16 @@ This document covers the Disaster Recovery testing procedure for applications ho
     - Deploy selected env
         - e.g. https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/.github/workflows/deploy-v2.yml
     - *Backup postgres database to Azure storage* [required for scenario 1 above]
-        - using https://github.com/DFE-Digital/github-actions/tree/master/backup-postgres
+        - using https://github.com/DFE-Digital/teacher-services-cloud/blob/main/templates/new_service/workflows/backup-db.yml
     - *Restore database from Azure storage* [required for scenario 1 above]
-        - using https://github.com/DFE-Digital/github-actions/tree/master/restore-postgres-backup
+        - using https://github.com/DFE-Digital/teacher-services-cloud/blob/main/templates/new_service/workflows/postgres-restore.yml
     - *Restore database from point in time to new database server* [required for scenario 2 above]
-        - using https://github.com/DFE-Digital/github-actions/tree/master/ptr-postgres
+        - using https://github.com/DFE-Digital/teacher-services-cloud/blob/main/templates/new_service/workflows/postgres-ptr.yml
 - Repo workflows to enable and disable the maintenance page.
     - see https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/maintenance-page.md
     - confirm workflows exists for the selected environment to be tested. Examples:
-        - https://github.com/DFE-Digital/apply-for-teacher-training/actions/workflows/enable-maintenance.yml
-        - https://github.com/DFE-Digital/apply-for-teacher-training/actions/workflows/disable-maintenance.yml
+        - https://github.com/DFE-Digital/teacher-services-cloud/blob/main/templates/new_service/workflows/enable-maintenance.yml
+        - https://github.com/DFE-Digital/teacher-services-cloud/blob/main/templates/new_service/workflows/disable-maintenance.yml
 - an app url that identifies the current docker image sha. Can be part of the healthcheck e.g. https://github.com/sdglhm/okcomputer/blob/master/lib/ok_computer/built_in_checks/app_version_check.rb
 - Identify the technical and non technical stakeholders who will participate in the test, based on the [Teacher services list](https://educationgovuk.sharepoint.com.mcas.ms/sites/teacher-services-infrastructure/Lists/Teacher%20services%20list/AllItems.aspx)
 

--- a/documentation/maintenance-page.md
+++ b/documentation/maintenance-page.md
@@ -52,7 +52,7 @@ flowchart LR;
 - Check the domains and kubernetes resource names in `new_service/maintenance_page/manifests`
 - Only production and development environments are provided as examples. Copy and amend for new environments.
 - If the service uses DSI, then add the temporary ingresses to the DSI configuration
-- Create workflows for enable-maintenance and disable-maintenance similar to https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/.github/workflows/enable-maintenance.yml and https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/.github/workflows/disable-maintenance.yml
+- Create workflows for enable-maintenance and disable-maintenance similar to https://github.com/DFE-Digital/teacher-services-cloud/blob/main/templates/new_service/workflows/enable-maintenance.yml and https://github.com/DFE-Digital/teacher-services-cloud/blob/main/templates/new_service/workflows/disable-maintenance.yml
 - The enable-maintenance workflow above should create a package with the correct permissions and visibility settings - if for some reason the workflow is missing or hasn't been run, the package will need to be manually set as public in [github packages](https://github.com/orgs/DFE-Digital/packages).
 - Test in each environment
 

--- a/documentation/onboard-service.md
+++ b/documentation/onboard-service.md
@@ -50,6 +50,12 @@ The code covers most common use cases, but it may be necessary to amend it. Exam
 - The only environment configurations are development and production. The service may need more or use different names.
 - The web application uses `/healthcheck` as health probe. It can be changed to another path or disabled by passing `null`.
 
+### Github actions workflow templates
+Several workflow templates will be created in the /workflows directory.
+These should be moved to the service repo .github/workflows directory and should be used as templates for post build tasks
+- postgres database backups and restores (as part of DR)
+- maintenance page enable/disable
+
 ## Prepare new environment
 These steps must be done by the infra team.
 

--- a/templates/new_service/workflows/backup-db.yml
+++ b/templates/new_service/workflows/backup-db.yml
@@ -1,0 +1,103 @@
+name: Backup database to Azure storage
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment to backup
+        required: true
+        default: development
+        type: choice
+        options:
+        - development
+        - test
+        - production
+      backup-file:
+        description: |
+          Backup file name (without extension). Default is #SERVICE_SHORT#_[env]_adhoc_YYYY-MM-DD. Set it explicitly when backing up a point-in-time (PTR) server. (Optional)
+        required: false
+        type: string
+        default: default
+      db-server:
+        description: |
+          Name of the database server. Default is the live server. When backing up a point-in-time (PTR) server, use the full name of the PTR server. (Optional)
+
+  # schedule:
+  #   - cron: "0 4 * * *" # 04:00 UTC
+
+env:
+  SERVICE_SHORT: #SERVICE_SHORT#
+  TF_VARS_PATH: terraform/aks/config
+
+jobs:
+  backup:
+    name: Backup database
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment || 'production' }}
+    env:
+      DEPLOY_ENV: ${{ inputs.environment || 'production'  }}
+      BACKUP_FILE: ${{ inputs.backup-file || 'schedule'  }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set environment variables
+      run: |
+        source global_config/${DEPLOY_ENV}.sh
+        tf_vars_file=${TF_VARS_PATH}/${DEPLOY_ENV}.tfvars.json
+        echo "CLUSTER=$(jq -r '.cluster' ${tf_vars_file})" >> $GITHUB_ENV
+        echo "RESOURCE_GROUP_NAME=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-rg" >> $GITHUB_ENV
+        echo "STORAGE_ACCOUNT_NAME=${AZURE_RESOURCE_PREFIX}${SERVICE_SHORT}dbbkp${CONFIG_SHORT}sa" >> $GITHUB_ENV
+        TODAY=$(date +"%F")
+        echo "DB_SERVER=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-pg" >> $GITHUB_ENV
+        if [ "${BACKUP_FILE}" == "schedule" ]; then
+          BACKUP_FILE=${SERVICE_SHORT}_${CONFIG_SHORT}_${TODAY}
+        elif [ "${BACKUP_FILE}" == "default" ]; then
+          BACKUP_FILE=${SERVICE_SHORT}_${CONFIG_SHORT}_adhoc_${TODAY}
+        else
+          BACKUP_FILE=${BACKUP_FILE}
+        fi
+        echo "BACKUP_FILE=${BACKUP_FILE}" >> $GITHUB_ENV
+        echo "KEYVAULT_NAME=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-inf-kv" >> $GITHUB_ENV
+
+    - name: Backup ${{ env.DEPLOY_ENV }} postgres
+      uses: DFE-Digital/github-actions/backup-postgres@master
+      with:
+        storage-account: ${{ env.STORAGE_ACCOUNT_NAME }}
+        resource-group: ${{ env.RESOURCE_GROUP_NAME }}
+        app-name: ${{ env.SERVICE_SHORT }}-${{ env.DEPLOY_ENV }} #or env.SERVICE_NAME?
+        cluster: ${{ env.CLUSTER }}
+        azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+        backup-file: ${{ env.BACKUP_FILE }}.sql
+        db-server-name: ${{ inputs.db-server }}
+
+    - name: Backup Summary
+      if: success()
+      run: |
+        NOW=$(TZ=Europe/London date +"%F %R")
+        echo 'BACKUP SUCCESSFUL!' >> $GITHUB_STEP_SUMMARY
+        echo '  ENV: ${{ env.DEPLOY_ENV }}' >> $GITHUB_STEP_SUMMARY
+        echo "  AT : ${NOW}" >> $GITHUB_STEP_SUMMARY
+        echo '  DB SERVER: ${{ inputs.db-server || env.DB_SERVER  }}' >> $GITHUB_STEP_SUMMARY
+        echo '  STORAGE ACCOUNT: ${{ env.STORAGE_ACCOUNT_NAME }}' >> $GITHUB_STEP_SUMMARY
+        echo '  FILENAME: ${{ env.BACKUP_FILE }}.sql.gz' >> $GITHUB_STEP_SUMMARY
+
+    - name: Get Slack webhook
+      uses: Azure/get-keyvault-secrets@v1
+      if: failure()
+      id: key-vault-secrets
+      with:
+        keyvault: ${{ env.KEYVAULT_NAME }}
+        secrets: "SLACK-WEBHOOK"
+
+    - name: Notify Slack channel on job failure
+      if: failure()
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_USERNAME: CI Deployment
+        SLACK_TITLE: Database backup failure
+        SLACK_MESSAGE: Production database backup job failed
+        SLACK_WEBHOOK: ${{ steps.key-vault-secrets.outputs.SLACK-WEBHOOK }}
+        SLACK_COLOR: failure
+        SLACK_FOOTER: Sent from backup job in backup-db workflow

--- a/templates/new_service/workflows/disable-maintenance.yml
+++ b/templates/new_service/workflows/disable-maintenance.yml
@@ -1,0 +1,41 @@
+name: Disable maintenance
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        required: true
+        type: choice
+        options:
+        - development
+        - production
+
+jobs:
+  disable-maintenance:
+    name: Disable maintenance app
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - uses: azure/login@v2
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - name: Set ARM and kubelogin environment
+      uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+      with:
+        azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - name: Disable maintenance app
+      run: make ${{ inputs.environment }} disable-maintenance
+
+    - name: Maintenance Summary
+      if: success()
+      run: |
+        NOW=$(TZ=Europe/London date +"%F %R")
+        echo 'MAINTENANCE PAGE DISABLED!' >> $GITHUB_STEP_SUMMARY
+        echo 'ENV: ${{ inputs.environment }}' >> $GITHUB_STEP_SUMMARY
+        echo "AT : ${NOW}" >> $GITHUB_STEP_SUMMARY

--- a/templates/new_service/workflows/enable-maintenance.yml
+++ b/templates/new_service/workflows/enable-maintenance.yml
@@ -1,0 +1,55 @@
+name: Enable maintenance
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        required: true
+        type: choice
+        options:
+        - development
+        - production
+
+jobs:
+  enable-maintenance:
+    name: Enable maintenance app
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build and push docker image
+      id: build-image
+      uses: DFE-Digital/github-actions/build-docker-image@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        dockerfile-path: maintenance_page/Dockerfile
+        docker-repository: ghcr.io/dfe-digital/itt-mentor-services-maintenance
+        context: maintenance_page
+
+    - uses: azure/login@v2
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - name: Set ARM and kubelogin environment
+      uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+      with:
+        azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - name: Deploy maintenance app
+      run: make ${{ inputs.environment }} maintenance-fail-over
+      env:
+        MAINTENANCE_IMAGE_TAG: ${{steps.build-image.outputs.tag}}
+
+    - name: Maintenance Summary
+      if: success()
+      run: |
+        NOW=$(TZ=Europe/London date +"%F %R")
+        echo 'MAINTENANCE PAGE ENABLED!' >> $GITHUB_STEP_SUMMARY
+        echo 'ENV: ${{ inputs.environment }}' >> $GITHUB_STEP_SUMMARY
+        echo "AT : ${NOW}" >> $GITHUB_STEP_SUMMARY
+        TEMP_URLS=$(awk '/name:.*cloud/ {print $2}' ./maintenance_page/manifests/${{ inputs.environment }}/ingress_temp*.yml)
+        echo 'TEMP URLS:' >> $GITHUB_STEP_SUMMARY
+        echo "${TEMP_URLS}" >> $GITHUB_STEP_SUMMARY

--- a/templates/new_service/workflows/postgres-ptr.yml
+++ b/templates/new_service/workflows/postgres-ptr.yml
@@ -1,0 +1,81 @@
+name: Restore database from point in time to new database server
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment to restore
+        required: true
+        default: development
+        type: choice
+        options:
+        - development
+        - test
+        - production
+      confirm-production:
+        description: Must be set to true if restoring production
+        required: true
+        default: 'false'
+        type: choice
+        options:
+        - 'false'
+        - 'true'
+      restore-time:
+        description: Restore point in time in UTC. e.g. 2024-07-24T06:00:00
+        type: string
+        required: true
+      new-db-server:
+        description: Name of the new database server. Default is <original-server-name>-ptr.
+        type: string
+
+env:
+  SERVICE_SHORT: #SERVICE_SHORT#
+  TF_VARS_PATH: terraform/aks/config
+
+jobs:
+  ptr-restore:
+    name: PTR Restore AKS Database
+    if: ${{ inputs.environment != 'production' || (inputs.environment == 'production' && github.event.inputs.confirm-production == 'true' )  }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    concurrency: deploy_${{ inputs.environment }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set environment variables
+      run: |
+        source global_config/${{ inputs.environment }}.sh
+        tf_vars_file=${TF_VARS_PATH}/${{ inputs.environment }}.tfvars.json
+        echo "CLUSTER=$(jq -r '.cluster' ${tf_vars_file})" >> $GITHUB_ENV
+        echo "RESOURCE_GROUP_NAME=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-rg" >> $GITHUB_ENV
+
+        DB_SERVER="${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-pg"
+        if [[ -n "${{ inputs.new-db-server }}" ]]; then
+          NEW_DB_SERVER="${{ inputs.new-db-server }}"
+        else
+          NEW_DB_SERVER="${DB_SERVER}-ptr"
+        fi
+        echo "DB_SERVER=${DB_SERVER}" >> $GITHUB_ENV
+        echo "NEW_DB_SERVER=${NEW_DB_SERVER}" >> $GITHUB_ENV
+
+    - name: Restore ${{ inputs.environment }} postgres
+      uses: DFE-Digital/github-actions/ptr-postgres@master
+      with:
+        resource-group: ${{ env.RESOURCE_GROUP_NAME }}
+        source-server: ${{ env.DB_SERVER }}
+        new-server: ${{ env.NEW_DB_SERVER }}
+        restore-time: ${{ inputs.restore-time }}
+        cluster: ${{ env.CLUSTER }}
+        azure-credentials: ${{ secrets.AZURE_CREDENTIALS}}
+
+    - name: Restore Summary
+      if: success()
+      run: |
+        NOW=$(TZ=Europe/London date +"%F %R")
+        echo 'RESTORE SUCCESSFUL!' >> $GITHUB_STEP_SUMMARY
+        echo '  ENV: ${{ inputs.environment }}' >> $GITHUB_STEP_SUMMARY
+        echo "  AT : ${NOW}" >> $GITHUB_STEP_SUMMARY
+        echo '  SOURCE SERVER: ${{ env.DB_SERVER }}' >> $GITHUB_STEP_SUMMARY
+        echo '  RESTORED SERVER: ${{ env.NEW_DB_SERVER }}' >> $GITHUB_STEP_SUMMARY
+        echo '  RESTORE POINT: ${{ inputs.restore-time }} UTC' >> $GITHUB_STEP_SUMMARY

--- a/templates/new_service/workflows/postgres-restore.yml
+++ b/templates/new_service/workflows/postgres-restore.yml
@@ -1,0 +1,79 @@
+name: Restore database from Azure storage
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment to restore
+        required: true
+        default: development
+        type: choice
+        options:
+        - development
+        - test
+        - production
+      confirm-production:
+        description: Must be set to true if restoring production
+        required: true
+        default: 'false'
+        type: choice
+        options:
+        - 'false'
+        - 'true'
+      backup-file:
+        description: Name of the backup file in Azure storage. e.g. #SERVICE_SHORT#_prod_2024-08-09.sql.gz. The default value is today's scheduled backup.
+        type: string
+        required: false
+
+env:
+  SERVICE_SHORT: #SERVICE_SHORT#
+  TF_VARS_PATH: terraform/aks/config
+
+jobs:
+  restore:
+    name: Restore AKS Database
+    if: ${{ inputs.environment != 'production' || (inputs.environment == 'production' && github.event.inputs.confirm-production == 'true' )  }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    concurrency: deploy_${{ inputs.environment }}
+
+    steps:
+    - uses: actions/checkout@v4
+      name: Checkout
+
+    - name: Set environment variables
+      run: |
+        source global_config/${{ inputs.environment }}.sh
+        tf_vars_file=${{ env.TF_VARS_PATH }}/${{ inputs.environment }}.tfvars.json
+        echo "CLUSTER=$(jq -r '.cluster' ${tf_vars_file})" >> $GITHUB_ENV
+        echo "RESOURCE_GROUP_NAME=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-rg" >> $GITHUB_ENV
+        echo "STORAGE_ACCOUNT_NAME=${AZURE_RESOURCE_PREFIX}${SERVICE_SHORT}dbbkp${CONFIG_SHORT}sa" >> $GITHUB_ENV
+        echo "DB_SERVER=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-pg" >> $GITHUB_ENV
+        TODAY=$(date +"%F")
+        echo "BACKUP_FILE=${SERVICE_SHORT}_${CONFIG_SHORT}_${TODAY}.sql" >> $GITHUB_ENV
+        if [ "${{ inputs.backup-file }}" != "" ]; then
+          BACKUP_FILE=${{ inputs.backup-file }}
+        else
+          BACKUP_FILE=${SERVICE_SHORT}_${CONFIG_SHORT}_${TODAY}.sql.gz
+        fi
+        echo "BACKUP_FILE=$BACKUP_FILE" >> $GITHUB_ENV
+
+    - name: Restore ${{ inputs.environment }} postgres
+      uses: DFE-Digital/github-actions/restore-postgres-backup@master
+      with:
+        storage-account: ${{ env.STORAGE_ACCOUNT_NAME }}
+        resource-group: ${{ env.RESOURCE_GROUP_NAME }}
+        app-name: ${{ env.SERVICE_SHORT }}-${{ inputs.environment }}
+        cluster: ${{ env.CLUSTER }}
+        azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+        backup-file: ${{ env.BACKUP_FILE }}
+
+    - name: Restore Summary
+      if: success()
+      run: |
+        NOW=$(TZ=Europe/London date +"%F %R")
+        echo 'RESTORE SUCCESSFUL!' >> $GITHUB_STEP_SUMMARY
+        echo '  ENV: ${{ inputs.environment }}' >> $GITHUB_STEP_SUMMARY
+        echo "  AT : ${NOW}" >> $GITHUB_STEP_SUMMARY
+        echo '  DB SERVER: ${{ env.DB_SERVER }}' >> $GITHUB_STEP_SUMMARY
+        echo '  BACKUP FILE RESTORED: ${{ env.BACKUP_FILE }}' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Context
https://trello.com/c/JPtELArk/2082-template-github-action-workflows

We want to add github workflow templates for common tasks.
This PR adds templates for existing workflows for DR and maintenance mode.
These will be added when make new_service is run, and can also be used as the master reference.

## Changes proposed in this pull request
Add workflow templates to templates/new_service/workflows
Update related documentation

## Guidance to review
Check doc and workflows
Can run make new_service to check workflows are created correctly

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
