### PR TITLE
add link to infrastructure team sharepoint docs

### DIFF
--- a/documentation/developer-onboarding.md
+++ b/documentation/developer-onboarding.md
@@ -2,6 +2,10 @@
 
 Documentation for the Teacher services application developers
 
+NOTE: For additional info for onboarding infrastructure team members see [
+Teacher services infrastructure -
+Onboarding a team member](https://educationgovuk.sharepoint.com.mcas.ms/sites/teacher-services-infrastructure/SitePages/Onboarding-a-team-member.aspx)
+
 ## Software requirements
 - OS: Linux, MacOS or Windows with WSL
 - [azure cli](https://technical-guidance.education.gov.uk/infrastructure/dev-tools/#azure-cli)

--- a/documentation/developer-onboarding.md
+++ b/documentation/developer-onboarding.md
@@ -2,9 +2,8 @@
 
 Documentation for the Teacher services application developers
 
-NOTE: For additional info for onboarding infrastructure team members see [
-Teacher services infrastructure -
-Onboarding a team member](https://educationgovuk.sharepoint.com.mcas.ms/sites/teacher-services-infrastructure/SitePages/Onboarding-a-team-member.aspx)
+NOTE: For additional info about infrastructure see [
+Sharepoint: Teacher services infrastructure](https://educationgovuk.sharepoint.com.mcas.ms/sites/teacher-services-infrastructure)
 
 ## Software requirements
 - OS: Linux, MacOS or Windows with WSL


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
developers have clear link to the infrastructure team sharepoint docs

## Changes proposed in this pull request
add link to infrastructure team sharepoint docs

## Guidance to review
check link works and see extra info on searching documentation



## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
