### PR TITLE
Maintenance Page template correction and documentation addition

### DIFF
--- a/documentation/maintenance-page.md
+++ b/documentation/maintenance-page.md
@@ -80,6 +80,16 @@ A user with write access to the repository must generate a token.
 ## Build image and enable maintenance
 - Run: `make <environment> enable-maintenance GITHUB_TOKEN=xxx`
 
+## Set Permissions on package image
+First time a package image is created the permissions need to be set manually:
+- Go to Github Packages https://github.com/orgs/DFE-Digital/packages and search for the maintenance package image built.
+- Click the name of the package that you want to manage.
+- Under your package versions, click Connect repository.
+- Select the repository to link to the package, then click Connect repository.
+- Then click on Package settings on right of page
+- In section Manage Actions access select Add Repository and add the repo and set access to Admin.
+- Finally, at bottom of page click Change package visibility and set to Public.
+
 ## Enable maintenance with an existing image
 You can deploy the maintenance image of a known tag:
 

--- a/templates/new_service/maintenance_page/manifests/maintenance/deployment_maintenance.yml.tmpl
+++ b/templates/new_service/maintenance_page/manifests/maintenance/deployment_maintenance.yml.tmpl
@@ -19,7 +19,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: #SERVICE_NAME#-maintenance
-        image: ghcr.io/dfe-digital/#SERVICE_NAME#-maintenance:#MAINTENANCE_IMAGE_TAG#
+        image: #DOCKER_REPOSITORY#-maintenance:#MAINTENANCE_IMAGE_TAG#
         ports:
         - containerPort: 8080
         resources:


### PR DESCRIPTION
## Context
fix bug and improve documentation in maintenance page 

## Changes proposed in this pull request
- fix bug in maintenance github workflow template related to docker repository parameter.
- add documentation on setting permissions for package image built

## Guidance to review
make new_service SERVICE_NAME=apply-for-qts SERVICE_SHORT=afqts SERVICE_PRETTY="Apply for qualified teacher status" DOCKER_REPOSITORY=ghcr.io/dfe-digital/apply-for-qualified-teacher-status NAMESPACE_PREFIX=tra DNS_ZONE_NAME=apply-for-qts-in-england.education.gov.uk

check new_service/.github/workflows/maintenance.yml has correct docker repository value

review documentation change for correctness

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
