### PR TITLE
Delete review app workflow template

### DIFF
--- a/templates/new_service/.github/workflows/delete-review-app.yml
+++ b/templates/new_service/.github/workflows/delete-review-app.yml
@@ -1,0 +1,54 @@
+name: Delete Review App
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number of review app to delete
+        required: true
+        type: string
+
+jobs:
+  delete-review-app:
+    name: Delete Review App ${{ github.event.pull_request.number }}
+    concurrency: deploy_review_${{ github.event.pull_request.number }}
+    environment: review
+    if: contains(github.event.pull_request.labels.*.name, 'deploy') ||  ${{ github.event_name }} == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
+    steps:
+      - name: set PR_NUMBER
+        id: config
+        run: |
+          if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
+            PR_NUMBER=${{ github.event.inputs.pr_number }}
+          else
+            PR_NUMBER=${{ github.event.pull_request.number }}
+          fi
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+          echo "ENVIRONMENT=pr-${PR_NUMBER})" >> $GITHUB_ENV
+
+      - name: Set environment variables
+        shell: bash
+        run: |
+          source global_config/review.sh
+          echo "AZURE_RESOURCE_PREFIX=${AZURE_RESOURCE_PREFIX}" >> $GITHUB_ENV
+          echo "CONFIG_SHORT=${CONFIG_SHORT}" >> $GITHUB_ENV
+
+      - name: Delete Review App
+        id: delete-review-app
+        uses: DFE-Digital/github-actions/delete-review-app@master
+        with:
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          container-name: terraform-state
+          gcp-wip: ${{ vars.GCP_WIP }}
+          gcp-project-id: ${{ vars.GCP_PROJECT_ID }}
+          pr-number: ${{ env.PR_NUMBER }}
+          resource-group-name: "${{ env.AZURE_RESOURCE_PREFIX }}-#SERVICE_SHORT#-${{ env.CONFIG_SHORT }}-rg"
+          storage-account-name: "${{ env.AZURE_RESOURCE_PREFIX }}#SERVICE_SHORT#${{ env.CONFIG_SHORT }}tfsa"
+          tf-state-file: "${{ env.ENVIRONMENT }}_kubernetes.tfstate"


### PR DESCRIPTION
## Context
to cleanup when a review app pr is closed 

## Changes proposed in this pull request
- destroying the review app 
- delete all versions of the terraform state in the azure storage account 

see also https://github.com/DFE-Digital/github-actions/pull/105

## Guidance to review

review code and 
see tested on a branch in https://github.com/DFE-Digital/refer-serious-misconduct/tree/delete-review-app
by running 
gh workflow run  delete-review-app.yml -r "delete-review-app" -f pr_number=1228
and you can see the action log at 
https://github.com/DFE-Digital/refer-serious-misconduct/actions/runs/11820195441

also test by running: 

make new_service SERVICE_NAME='refer-serious-misconduct' SERVICE_SHORT=rsm SERVICE_PRETTY="Refer Serious Misconduct" DOCKER_REPOSITORY='ghcr.io/dfe-digital/refer-serious-misconduct' NAMESPACE_PREFIX=tra DNS_ZONE_NAME='refer-serious-misconduct.education.gov.uk/'

Trello Card [delete review app workflow template](https://trello.com/c/IqDW5aC8/2092-delete-review-app-workflow-template)

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
