### PR TITLE
[2137] Use stable terraform module in production custom_domains

### DIFF
--- a/custom_domains/terraform/infrastructure/config/tscp_Terrafile
+++ b/custom_domains/terraform/infrastructure/config/tscp_Terrafile
@@ -1,3 +1,3 @@
 domains:
     source:  "https://github.com/DFE-Digital/terraform-modules"
-    version: "testing"
+    version: "stable"


### PR DESCRIPTION
## Context
The txt_record_list feature is now released to stable

## Changes proposed in this pull request
Change prod custom domain terrafile to stable

## Guidance to review
Run `make prod-domain domains-infra-plan CONFIRM_PROD_DOMAIN=yes`
It should work and show no change

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
