### PR TITLE
[2105] Remove null_host_header option from domains template

### DIFF
--- a/templates/new_service/terraform/domains/environment_domains/main.tf
+++ b/templates/new_service/terraform/domains/environment_domains/main.tf
@@ -8,6 +8,5 @@ module "domains" {
   domains             = each.value.domains
   environment         = each.value.environment_short
   host_name           = each.value.origin_hostname
-  null_host_header    = try(each.value.null_host_header, false)
   cached_paths        = try(each.value.cached_paths, [])
 }


### PR DESCRIPTION
## Context
The standard is to use the default value

## Changes proposed in this pull request
Remove null_host_header

## Guidance to review
https://github.com/DFE-Digital/register-early-career-teachers/pull/756

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
