### PR TITLE
Improve disaster recovery docs

### DIFF
--- a/documentation/disaster-recovery-testing.md
+++ b/documentation/disaster-recovery-testing.md
@@ -48,7 +48,7 @@ Note that you must have a previously created backup on azure storage before star
 - Delete the existing postgres database
     - manually delete via UI https://portal.azure.com/#browse/Microsoft.DBforPostgreSQL%2FflexibleServers
 - Confirm it's deleted
-- Check and delete any postgres diagnostics remaining for the deleted instance in https://portal.azure.com/#view/Microsoft_Azure_Monitoring/AzureMonitoringBrowseBlade/~/diagnosticsLogs as the later deploy to rebuild postgres will fail if it remains. e.g. s189t01-ittms-stg-pg-diagnotics
+- Check and delete any postgres diagnostics remaining for the deleted instance in https://portal.azure.com/#view/Microsoft_Azure_Monitoring/AzureMonitoringBrowseBlade/~/diagnosticsLogs as the later deploy to rebuild postgres will fail if it remains. e.g. search using subscription s189-teacher-services-cloud-test and resource group s189t01-ittms-stg-pg and look for enabled Diagnostic settings.
 
 Follow the disaster recovery instructions.
 

--- a/documentation/disaster-recovery.md
+++ b/documentation/disaster-recovery.md
@@ -29,7 +29,11 @@ Alert developers that no one should merge to main.
 
 Run the *Enable maintenance* workflow for the service and environment affected.
 
-The maintenance page message can be [updated](https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/maintenance-page.md#update-content) at any time during the incident
+The maintenance page message can be [updated](https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/maintenance-page.md#update-content) at any time during the incident.
+
+e.g. https://claim-additional-payments-for-teaching-test-web.test.teacherservices.cloud will now display the maintenance page and
+
+https://claim-additional-payments-for-teaching-temp.test.teacherservices.cloud will display the application.
 
 ### Recreate the lost postgres database server
 
@@ -46,6 +50,9 @@ Run the *Restore database from Azure storage* workflow.
 
 ### Validate app
 Confirm the app is working and can see the restored data. The app is available on the [temporary ingress](maintenance-page.md/#fail-over) URL.
+
+e.g. https://claim-additional-payments-for-teaching-temp.test.teacherservices.cloud will display the application.
+
 
 ### Disable maintenance mode
 Run the *Disable maintenance* workflow for the service and environment affected.


### PR DESCRIPTION
## Context
Improve disaster recovery docs based on latest claims dr test

## Changes proposed in this pull request
 improve docs about removing azure Monitor Diagnostic settings
 add examples of urls after maintenance page enabled. 

## Guidance to review
review correctness of changes and format and spelling. 

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
