### PR TITLE
platform-test: Upgrade AKS from 1.29.7 to 1.30.6

### DIFF
--- a/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.29.7",
+  "kubernetes_version": "1.30.6",
   "default_node_pool": {
     "node_count": 2,
-    "orchestrator_version": "1.29.7"
+    "orchestrator_version": "1.30.6"
   },
   "node_pools": {
     "apps1": {
@@ -12,7 +12,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.29.7"
+      "orchestrator_version": "1.30.6"
     }
   },
   "admin_group_id": "f726cc54-78cb-4c98-89a6-b8e4396afb98",


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
<!-- Why are we making this change? New feature? Bug fix? -->
There is a requirement to keep up with the Kubernetes releases for bug fixes and new functionality. Our clusters are currently on 1.29

## Changes proposed in this pull request
<!-- Describe briefly the technical implementation -->
<!-- Show any dependencies between pull requests, i.e. this must be merged before or after another -->
Upgrade the Kubernetes cluster from 1.29.7 to 1.30.6.



## Guidance to review
<!-- Show how this can be tested or evidence that it is working -->
platform-test cluster configuration for kubernetes cluster, orchestrator version for all node pools from 1.29.7 to 1.30.6


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
