### PR TITLE
Enable srtl namespaces  for gcp wif

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -15,6 +15,7 @@
   "gcp_wif_namespaces": [
     "bat-production",
     "git-production",
+    "srtl-production",
     "tra-production",
     "tv-production"
   ],

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -23,6 +23,8 @@
     "bat-staging",
     "git-development",
     "git-test",
+    "srtl-development",
+    "srtl-test",
     "tra-development",
     "tra-test",
     "tv-development",


### PR DESCRIPTION
## Context
srtl namespaces need to be enabled for gcp wif so application in these namespaces can be configured for gcp wif

## Changes proposed in this pull request
add the srtl namespaces to config for aks test cluster and production cluster

## Guidance to review
review change for any typos.

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
