### PR TITLE
[2151] Enable Github actions OIDC for services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ terraform-aks-cluster-destroy: terraform-aks-cluster-init
 
 terraform-kubernetes-init: set-azure-account
 	rm -rf cluster/terraform_kubernetes/vendor/modules/aks
-	git clone --depth=1 --single-branch --branch ${TERRAFORM_MODULES_TAG} https://github.com/DFE-Digital/terraform-modules.git cluster/terraform_kubernetes/vendor/modules/aks
+	git -c advice.detachedHead=false clone --depth=1 --single-branch --branch ${TERRAFORM_MODULES_TAG} https://github.com/DFE-Digital/terraform-modules.git cluster/terraform_kubernetes/vendor/modules/aks
 
 	terraform -chdir=cluster/terraform_kubernetes init -reconfigure -upgrade \
 		-backend-config=resource_group_name=${RESOURCE_GROUP_NAME} \

--- a/cluster/terraform_aks_cluster/.terraform.lock.hcl
+++ b/cluster/terraform_aks_cluster/.terraform.lock.hcl
@@ -7,6 +7,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   hashes = [
     "h1:2QbjtN4oMXzdA++Nvrj/wSmWZTPgXKOSFGGQCLEMrb4=",
     "h1:BCR3NIorFSvGG3v/+JOiiw3VM4PkChLO4m84wzD9NDo=",
+    "h1:SJM/KQDW9blKFmLMaupsZVYtcZ0fYpjLHEriMgCBGCY=",
     "zh:02b6606aff025fc2a962b3e568e000300abe959adac987183c24dac8eb057f4d",
     "zh:2a23a8ce24ff9e885925ffee0c3ea7eadba7a702541d05869275778aa47bdea7",
     "zh:57d10746384baeca4d5c56e88872727cdc150f437b8c5e14f0542127f7475e24",

--- a/cluster/terraform_kubernetes/.terraform.lock.hcl
+++ b/cluster/terraform_kubernetes/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/eppo/environment" {
   constraints = "1.3.5"
   hashes = [
     "h1:1Af95/IhzW16rbX8kSApfrAi8vwc5+7uVbCeyVaGw2E=",
+    "h1:J0rtl6GrLyBKYz6PQ5BXsyYfjHbgMEoAHEQQ3u0vPBc=",
     "h1:pceowuRAKcjLd+g4noIJdX6CBIWavlM4BvRTsGfH0uQ=",
     "zh:00e7a6bf7f0f09cc4871d7f4fee2c943ce61c05b9802365a97703d6c2e63e3dc",
     "zh:018d92e621177d053ed5c32e8220efa8c019852c4d60cc7539683bac28470d9b",
@@ -31,6 +32,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   hashes = [
     "h1:2QbjtN4oMXzdA++Nvrj/wSmWZTPgXKOSFGGQCLEMrb4=",
     "h1:BCR3NIorFSvGG3v/+JOiiw3VM4PkChLO4m84wzD9NDo=",
+    "h1:SJM/KQDW9blKFmLMaupsZVYtcZ0fYpjLHEriMgCBGCY=",
     "zh:02b6606aff025fc2a962b3e568e000300abe959adac987183c24dac8eb057f4d",
     "zh:2a23a8ce24ff9e885925ffee0c3ea7eadba7a702541d05869275778aa47bdea7",
     "zh:57d10746384baeca4d5c56e88872727cdc150f437b8c5e14f0542127f7475e24",
@@ -51,6 +53,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   constraints = "2.15.0"
   hashes = [
     "h1:VymvscRkDy0+zN2uKpKYY6njXPY8JROARuaL3VPsEos=",
+    "h1:WfjJptfaDzC4XCht262FFizAMX8fvRDZWtqUmuLcg88=",
     "h1:qPUoXPUCizzPS8tlJydH+VBXeiOeizOiSEOaNqZEyMY=",
     "zh:18b94c7c83c30ad166722a61a412e3de6a67935772960e79aaa24c15f8ea0d0f",
     "zh:4f07c929a71e8169f7471b7600bfcca36dfb295787e975e82ac0455a3ab68b47",
@@ -73,6 +76,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   hashes = [
     "h1:3j4XBR5UWQA7xXaiEnzZp0bHbcwOhWetHYKTWIrUTI0=",
     "h1:Cj3RHyw3wE3AkNlCtSNrZfjFNkShvaZR0K/K3pJlYJU=",
+    "h1:HqeU0sZBh+2loFYqPMFx7jJamNUPEykyqJ9+CkMCYE0=",
     "zh:0e715d7fb13a8ad569a5fdc937b488590633f6942e986196fdb17cd7b8f7720e",
     "zh:495fc23acfe508ed981e60af9a3758218b0967993065e10a297fdbc210874974",
     "zh:4b930a8619910ef528bc90dae739cb4236b9b76ce41367281e3bc3cf586101c7",
@@ -92,6 +96,7 @@ provider "registry.terraform.io/statuscakedev/statuscake" {
   version     = "2.2.2"
   constraints = "2.2.2"
   hashes = [
+    "h1:OoqL/K/eNLahbfMwJvYZHo9kacafjtrJKhd6cLrubZ4=",
     "h1:nVaJkDBk4sv0yWFzg3p+yeJGzE8mB4KJv3Q6/UgU164=",
     "h1:wFoZJfmNvG6XTf65NLai67geSHqYV1Tilx7OITrHilE=",
     "zh:0916313344c579d6e05d70f88129a10fe48f7dabe0e61cad17874d6c496f288d",

--- a/cluster/terraform_kubernetes/config/development.tfvars.json
+++ b/cluster/terraform_kubernetes/config/development.tfvars.json
@@ -17,5 +17,10 @@
   "thanos_retention_5m": "10d",
   "thanos_retention_1h": "12d",
   "cluster_short": "dv",
-  "block_metrics_endpoint" : false
+  "block_metrics_endpoint" : false,
+  "ga_wif_managed_id": {
+    "bat": {
+      "itt-mentor-services": ["dv_review"]
+    }
+  }
 }

--- a/cluster/terraform_kubernetes/config/platform-test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/platform-test.tfvars.json
@@ -26,5 +26,10 @@
   "thanos_retention_1h": "12d",
   "cluster_short": "pt",
   "alertmanager_slack_receiver_list": [],
-  "alertable_apps": {}
+  "alertable_apps": {},
+  "ga_wif_managed_id": {
+    "bat": {
+      "itt-mentor-services": ["pt_review"]
+    }
+  }
 }

--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -124,5 +124,10 @@
     "tra-production/refer-serious-misconduct-production-worker": {
       "receiver": "SLACK_WEBHOOK_RSM"
     }
+  },
+  "github_actions_mi": {
+    "bat-production": {
+      "ittms": ["sandbox", "production"]
+    }
   }
 }

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -88,5 +88,10 @@
     "SLACK_WEBHOOK_PTT",
     "SLACK_WEBHOOK_GENERIC"
   ],
-  "block_metrics_endpoint" : false
+  "block_metrics_endpoint" : false,
+  "ga_wif_managed_id": {
+    "bat": {
+      "itt-mentor-services": ["review", "qa", "staging"]
+    }
+  }
 }

--- a/cluster/terraform_kubernetes/data.tf
+++ b/cluster/terraform_kubernetes/data.tf
@@ -6,3 +6,5 @@ data "azurerm_key_vault" "key_vault" {
 data "azurerm_key_vault_secrets" "main" {
   key_vault_id = data.azurerm_key_vault.key_vault.id
 }
+
+data "azurerm_subscription" "current" {}

--- a/cluster/terraform_kubernetes/github_actions_wif.tf
+++ b/cluster/terraform_kubernetes/github_actions_wif.tf
@@ -1,0 +1,36 @@
+resource "azurerm_user_assigned_identity" "ga_wif" {
+  for_each = var.ga_wif_managed_id
+
+  location            = data.azurerm_resource_group.resource_group.location
+  name                = "${var.resource_prefix}-ga-wif-${var.config}-${each.key}-id"
+  resource_group_name = var.resource_group_name
+}
+
+locals {
+  # Iterate over ga_wif_namespaces, repos and environments to create a list of maps
+  ga_wif_credentials = flatten([
+    for group, repos in var.ga_wif_managed_id : [
+      for repo, environments in repos : [
+        for environment in environments : {
+          g = group
+          r = repo
+          e = environment
+        }
+      ]
+    ]
+  ])
+}
+
+resource "azurerm_federated_identity_credential" "github_actions_wif" {
+  for_each = {
+    # Create a map from the list by generating unique keys
+    for creds in local.ga_wif_credentials : "${creds.r}-${creds.e}" => creds
+  }
+
+  name                = each.key
+  resource_group_name = var.resource_group_name
+  parent_id           = azurerm_user_assigned_identity.ga_wif[each.value.g].id
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = "https://token.actions.githubusercontent.com"
+  subject             = "repo:DFE-Digital/${each.value.r}:environment:${each.value.e}"
+}

--- a/cluster/terraform_kubernetes/output.tf
+++ b/cluster/terraform_kubernetes/output.tf
@@ -1,3 +1,16 @@
 output "welcome_app_url" {
   value = "https://${local.default_welcome_app_hostname}/"
 }
+
+output "ga_wif_config" {
+  description = "Configuration for workflows of services declared in var.ga_wif_namespaces"
+
+  value = { for m in keys(var.ga_wif_managed_id) :
+    m => {
+      managed_id_name = azurerm_user_assigned_identity.ga_wif[m].name
+      client_id       = azurerm_user_assigned_identity.ga_wif[m].client_id
+      tenant_id       = azurerm_user_assigned_identity.ga_wif[m].tenant_id
+      subscription_id = data.azurerm_subscription.current.subscription_id
+    }
+  }
+}

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -225,6 +225,11 @@ variable "block_metrics_endpoint" {
   type        = bool
 }
 
+variable "ga_wif_managed_id" {
+  default = {}
+  type    = map(map(list(string)))
+}
+
 locals {
   cluster_name = (
     var.cip_tenant ?

--- a/templates/new_service/.github/workflows/backup-db.yml
+++ b/templates/new_service/.github/workflows/backup-db.yml
@@ -46,7 +46,9 @@ jobs:
 
     - uses: azure/login@v2
       with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
+        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
 
     - name: Set environment variables
       run: |
@@ -83,7 +85,9 @@ jobs:
         resource-group: ${{ env.RESOURCE_GROUP_NAME }}
         app-name: #SERVICE_NAME#-${{ env.DEPLOY_ENV }}
         cluster: ${{ env.CLUSTER }}
-        azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         backup-file: ${{ env.BACKUP_FILE }}.sql
         db-server-name: ${{ inputs.db-server }}
         slack-webhook: ${{ steps.key-vault-secrets.outputs.SLACK_WEBHOOK }}

--- a/templates/new_service/.github/workflows/build-and-deploy.yml
+++ b/templates/new_service/.github/workflows/build-and-deploy.yml
@@ -94,7 +94,9 @@ jobs:
       id: deploy_review
       uses: DFE-Digital/github-actions/deploy-to-aks@master
       with:
-        azure-credentials:  ${{ secrets.AZURE_CREDENTIALS }}
+        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         environment: review
         pr-number: ${{ github.event.pull_request.number }}
         sha: ${{ needs.build.outputs.docker-image-tag }}
@@ -126,7 +128,9 @@ jobs:
       id: deploy_app
       uses: DFE-Digital/github-actions/deploy-to-aks@master
       with:
-        azure-credentials:  ${{ secrets.AZURE_CREDENTIALS }}
+        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         environment: ${{ matrix.environment }}
         pr-number: ${{ github.event.pull_request.number }}
         sha: ${{ needs.build.outputs.docker-image-tag }}
@@ -153,7 +157,9 @@ jobs:
       id: deploy_manual
       uses: DFE-Digital/github-actions/deploy-to-aks@master
       with:
-        azure-credentials:  ${{ secrets.AZURE_CREDENTIALS }}
+        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         environment: ${{ inputs.environment }}
         pr-number: ${{ inputs.pull-request-number }}
         sha: ${{ inputs.docker-image-tag }}

--- a/templates/new_service/.github/workflows/delete-review-app.yml
+++ b/templates/new_service/.github/workflows/delete-review-app.yml
@@ -44,7 +44,9 @@ jobs:
         id: delete-review-app
         uses: DFE-Digital/github-actions/delete-review-app@master
         with:
-          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           container-name: terraform-state
           gcp-wip: ${{ vars.GCP_WIP }}
           gcp-project-id: ${{ vars.GCP_PROJECT_ID }}

--- a/templates/new_service/.github/workflows/maintenance.yml
+++ b/templates/new_service/.github/workflows/maintenance.yml
@@ -29,7 +29,9 @@ jobs:
     - name: Enable or disable maintenance mode
       uses: DFE-Digital/github-actions/maintenance@master
       with:
-        azure-credentials: ${{ secrets.AZURE_CREDENTIALS}}
+        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         environment: ${{ inputs.environment }}
         mode: ${{ inputs.mode }}
         docker-repository: #DOCKER_REPOSITORY#-maintenance

--- a/templates/new_service/.github/workflows/postgres-ptr.yml
+++ b/templates/new_service/.github/workflows/postgres-ptr.yml
@@ -67,4 +67,6 @@ jobs:
         new-server: ${{ env.NEW_DB_SERVER }}
         restore-time: ${{ inputs.restore-time }}
         cluster: ${{ env.CLUSTER }}
-        azure-credentials: ${{ secrets.AZURE_CREDENTIALS}}
+        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/templates/new_service/.github/workflows/postgres-restore.yml
+++ b/templates/new_service/.github/workflows/postgres-restore.yml
@@ -66,5 +66,7 @@ jobs:
         resource-group: ${{ env.RESOURCE_GROUP_NAME }}
         app-name: ${{ env.SERVICE_NAME }}-${{ inputs.environment }}
         cluster: ${{ env.CLUSTER }}
-        azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         backup-file: ${{ env.BACKUP_FILE }}

--- a/templates/new_service/Makefile
+++ b/templates/new_service/Makefile
@@ -43,7 +43,7 @@ terraform-init: composed-variables set-azure-account
 	$(if ${DOCKER_IMAGE_TAG}, , $(eval DOCKER_IMAGE_TAG=main))
 
 	rm -rf terraform/application/vendor/modules/aks
-	git clone --depth=1 --single-branch --branch ${TERRAFORM_MODULES_TAG} https://github.com/DFE-Digital/terraform-modules.git terraform/application/vendor/modules/aks
+	git -c advice.detachedHead=false clone --depth=1 --single-branch --branch ${TERRAFORM_MODULES_TAG} https://github.com/DFE-Digital/terraform-modules.git terraform/application/vendor/modules/aks
 
 	terraform -chdir=terraform/application init -upgrade -reconfigure \
 		-backend-config=resource_group_name=${RESOURCE_GROUP_NAME} \

--- a/templates/new_service/terraform/application/terraform.tf
+++ b/templates/new_service/terraform/application/terraform.tf
@@ -27,17 +27,12 @@ provider "azurerm" {
 
 provider "kubernetes" {
   host                   = module.cluster_data.kubernetes_host
-  client_certificate     = module.cluster_data.kubernetes_client_certificate
-  client_key             = module.cluster_data.kubernetes_client_key
   cluster_ca_certificate = module.cluster_data.kubernetes_cluster_ca_certificate
 
-  dynamic "exec" {
-    for_each = module.cluster_data.azure_RBAC_enabled ? [1] : []
-    content {
-      api_version = "client.authentication.k8s.io/v1beta1"
-      command     = "kubelogin"
-      args        = module.cluster_data.kubelogin_args
-    }
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "kubelogin"
+    args        = module.cluster_data.kubelogin_args
   }
 }
 


### PR DESCRIPTION
## Context
Create federated credentials so that github actions for all services can authenticate using OIDC instead of service principal secret

Depends on:
- https://github.com/DFE-Digital/github-actions/pull/106
- https://github.com/DFE-Digital/terraform-modules/pull/140

## Changes proposed in this pull request
- Create managed identities and federated credentials for ITTMS and Publish
- Update new_service template
- Update documentation

## Guidance to review
- See https://github.com/DFE-Digital/itt-mentor-services/pull/1253
- Review documentation

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
