### PR TITLE
feat: Adding prometheus alert rules for disk and node pressure

### DIFF
--- a/cluster/terraform_kubernetes/config/prometheus/alertmanager/node_alert.rules.tmpl
+++ b/cluster/terraform_kubernetes/config/prometheus/alertmanager/node_alert.rules.tmpl
@@ -11,3 +11,25 @@ groups:
       severity: high
       cluster: ${cluster_long}
       receiver: SLACK_WEBHOOK_GENERIC
+
+  - alert: KubernetesNodeMemoryPressure
+    expr: kube_node_status_condition{condition="MemoryPressure",status="true"} == 1
+    for: 2m
+    annotations:
+      summary: Kubernetes Node memory pressure (instance {{ $labels.instance }})
+      description: "Node {{ $labels.nodename }} has MemoryPressure condition\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+    labels:
+      severity: critical
+      cluster: ${cluster_long}
+      receiver: SLACK_WEBHOOK_GENERIC
+
+  - alert: KubernetesNodeDiskPressure
+    expr: kube_node_status_condition{condition="DiskPressure",status="true"} == 1
+    for: 2m
+    annotations:
+      summary: Kubernetes Node disk pressure (instance {{ $labels.instance }})
+      description: "Node {{ $labels.nodename }} has DiskPressure condition\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+    labels:
+      severity: critical
+      cluster: ${cluster_long}
+      receiver: SLACK_WEBHOOK_GENERIC


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context

We are adding a Prometheus alert to alert on high disk pressure or node pressure.

## Changes proposed in this pull request

Adding additional alert rules

## Guidance to review

Can query Prometheus dashboard UI to view the metrics.

<img width="1241" alt="Screenshot 2025-01-08 at 17 04 44" src="https://github.com/user-attachments/assets/b9d7957b-e4af-4198-8a6c-a4639ec5ff16" />


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
