### PR TITLE
1715 alertmanager config reloader

### DIFF
--- a/cluster/terraform_kubernetes/alertmanager.tf
+++ b/cluster/terraform_kubernetes/alertmanager.tf
@@ -41,6 +41,9 @@ resource "kubernetes_deployment" "alertmanager" {
         labels = {
           app = "alertmanager"
         }
+        annotations = {
+          "reloader.stakater.com/auto" = "true"
+        }
       }
 
       spec {

--- a/cluster/terraform_kubernetes/reloader.tf
+++ b/cluster/terraform_kubernetes/reloader.tf
@@ -1,0 +1,32 @@
+resource "helm_release" "reloader" {
+  name       = "reloader"
+  namespace  = "monitoring"
+  repository = "https://stakater.github.io/stakater-charts"
+  chart      = "reloader"
+  version    = var.reloader_version
+
+  set {
+    name  = "reloader.watchGlobally"
+    value = "true"
+  }
+
+  set {
+    name  = "reloader.deployment.resources.limits.memory"
+    value = var.reloader_app_mem
+  }
+
+  set {
+    name  = "reloader.deployment.resources.limits.cpu"
+    value = var.reloader_app_cpu
+  }
+
+  set {
+    name  = "reloader.deployment.resources.requests.memory"
+    value = var.reloader_app_mem
+  }
+
+  set {
+    name  = "reloader.deployment.resources.requests.cpu"
+    value = var.reloader_app_cpu
+  }
+}

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -207,6 +207,24 @@ variable "filebeat_version" {
   default = "8.12.2"
 }
 
+variable "reloader_version" {
+  type        = string
+  description = "Version of the Reloader helm chart to use"
+  default     = "1.0.69"
+}
+
+variable "reloader_app_cpu" {
+  type        = string
+  description = "Reloader app cpu request/limit"
+  default     = "100m"
+}
+
+variable "reloader_app_mem" {
+  type        = string
+  description = "Reloader app memory request/limit"
+  default     = "512Mi"
+}
+
 variable "alertmanager_slack_receiver_list" {
   type        = list(any)
   description = "List of alertmanager Slack receivers. Each entry must have a corresponding webhook in the keyvault."


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context

Allow Alertmanager to dynamically redeploy if the CM is updated

## Changes proposed in this pull request

Installation of reloader with the necessary annotation applied to the Alertmanager deployment

## Guidance to review

<img width="828" alt="Screenshot 2025-01-13 at 14 06 42" src="https://github.com/user-attachments/assets/19eb02e3-a2cc-45f9-b5d8-236a1ca8f47f" />

You can also test yourself by adding the annotation to a deployment and then changing any configmap referenced in the deploymenhy.

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
