### PR TITLE
Alertmanager config reloader container

### DIFF
--- a/cluster/terraform_kubernetes/alertmanager.tf
+++ b/cluster/terraform_kubernetes/alertmanager.tf
@@ -41,6 +41,9 @@ resource "kubernetes_deployment" "alertmanager" {
         labels = {
           app = "alertmanager"
         }
+        annotations = {
+          "reloader.stakater.com/auto" = "true"
+        }
       }
 
       spec {

--- a/cluster/terraform_kubernetes/reloader.tf
+++ b/cluster/terraform_kubernetes/reloader.tf
@@ -1,0 +1,32 @@
+resource "helm_release" "reloader" {
+  name       = "reloader"
+  namespace  = "monitoring"
+  repository = "https://stakater.github.io/stakater-charts"
+  chart      = "reloader"
+  version    = var.reloader_version
+
+  set {
+    name  = "reloader.watchGlobally"
+    value = "true"
+  }
+
+  set {
+    name  = "reloader.deployment.resources.limits.memory"
+    value = var.reloader_app_mem
+  }
+
+  set {
+    name  = "reloader.deployment.resources.limits.cpu"
+    value = var.reloader_app_cpu
+  }
+
+  set {
+    name  = "reloader.deployment.resources.requests.memory"
+    value = var.reloader_app_mem
+  }
+
+  set {
+    name  = "reloader.deployment.resources.requests.cpu"
+    value = var.reloader_app_cpu
+  }
+}

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -209,7 +209,7 @@ variable "filebeat_version" {
 
 variable "reloader_version" {
   type        = string
-  description = "Version of the Reloader helm chart to use"
+  description = "Version of the Reloader container image to use"
   default     = "1.0.69"
 }
 

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -207,6 +207,24 @@ variable "filebeat_version" {
   default = "8.12.2"
 }
 
+variable "reloader_version" {
+  type        = string
+  description = "Version of the Reloader helm chart to use"
+  default     = "1.0.69"
+}
+
+variable "reloader_app_cpu" {
+  type        = string
+  description = "Reloader app cpu request/limit"
+  default     = "100m"
+}
+
+variable "reloader_app_mem" {
+  type        = string
+  description = "Reloader app memory request/limit"
+  default     = "512Mi"
+}
+
 variable "alertmanager_slack_receiver_list" {
   type        = list(any)
   description = "List of alertmanager Slack receivers. Each entry must have a corresponding webhook in the keyvault."


### PR DESCRIPTION
## Context
Adding reloader to the cluster with Terraform resources

## Changes proposed in this pull request

Adding reloader to the cluster with Terraform resources

## Guidance to review

Change a config map when the annotation for reloader is applied and watch the deployment dynamically restart

<img width="654" alt="Screenshot 2025-01-15 at 14 31 11" src="https://github.com/user-attachments/assets/d00f2854-3b88-4b2f-a856-e65e1410a3f8" />


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
