### PR TITLE
Add dev cluster env to ga_wif naming

### DIFF
--- a/cluster/terraform_kubernetes/github_actions_wif.tf
+++ b/cluster/terraform_kubernetes/github_actions_wif.tf
@@ -2,7 +2,7 @@ resource "azurerm_user_assigned_identity" "ga_wif" {
   for_each = var.ga_wif_managed_id
 
   location            = data.azurerm_resource_group.resource_group.location
-  name                = "${var.resource_prefix}-ga-wif-${var.config}-${each.key}-id"
+  name                = "${var.resource_prefix}-ga-wif-${var.environment}-${each.key}-id"
   resource_group_name = var.resource_group_name
 }
 


### PR DESCRIPTION
## Context
ga_wif naming doesn't include the dev cluster env, so cluster build fails if one already exists

Error: A resource with the ID "/subscriptions/nnnnnnn/resourceGroups/s189d01-tsc-dv-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s189d01-ga-wif-development-bat-id" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_user_assigned_identity" for more information.

## Changes proposed in this pull request
use var.environment instead of var.config
this will create s189d01-ga-wif-**clustern**-bat-id  instead of s189d01-ga-wif-**development**-bat-id

## Guidance to review
see dev cluster 1
make env deploy-plan makes no changes to test, production clusters

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
