### PR TITLE
[2151] Deploy ITTMS latest commit tag instead of "main"

### DIFF
--- a/.github/actions/test-app-deployment/action.yml
+++ b/.github/actions/test-app-deployment/action.yml
@@ -30,8 +30,13 @@ runs:
     shell: bash
     working-directory: itt-mentor-services
     run: |
+      # Get terraform version
       terraform_version=$(awk '/{/{f=/^terraform/;next}f' terraform/application/terraform.tf | grep -o [0-9\.]*)
       echo "TERRAFORM_VERSION=$terraform_version" >> $GITHUB_ENV
+
+      # Get latest commit id on main to fetch the corresponding docker tag
+      COMMIT_ID=$(git rev-parse HEAD)
+      echo "COMMIT_ID=$COMMIT_ID" >> $GITHUB_ENV
 
   - name: Use Terraform ${{ env.TERRAFORM_VERSION }}
     uses: hashicorp/setup-terraform@v3
@@ -50,7 +55,7 @@ runs:
     working-directory: itt-mentor-services
     run: make ${{ inputs.environment }} ci terraform-apply
     env:
-      DOCKER_IMAGE_TAG: main
+      DOCKER_IMAGE_TAG: ${{ env.COMMIT_ID }}
       PR_NUMBER: 9999
 
   - name: Run healthcheck


### PR DESCRIPTION
## Context
The main tag is not deterministic and might deploy an old image if it's cached on the AKS node

## Changes proposed in this pull request
Determine the latest commit id and use it to determine the latest docker tag

## Guidance to review
Successful run: https://github.com/DFE-Digital/teacher-services-cloud/actions/runs/12928764567/job/36056753462


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
