### PR TITLE
Add logit DfEAnalyticsSendEvents msg supression

### DIFF
--- a/documentation/logit-io.md
+++ b/documentation/logit-io.md
@@ -140,6 +140,18 @@ filter {
       remove_field => ["message"]
     }
 
+    # TEMP drop DfE::Analytics::SendEvents of Type Info
+    if ([app][payload][job_class] == "DfE::Analytics::SendEvents" and [app][level] == "info") {
+    	drop {}
+  	}
+
+    # TEMP remove stack_trace for DfE::Analytics::SendEvents of Type error
+    if ([app][payload][job_class] == "DfE::Analytics::SendEvents" and [app][level] == "error") {
+    	mutate {
+        	remove_field => "[app][exception][stack_trace]"
+        }
+    }
+
     # Remove stack trace for 404 errors in rails apps, as it is large and adds no value
     if [app][exception][name] == "ActionController::RoutingError" {
       mutate {


### PR DESCRIPTION
## Context
Added logit logstash pipeline update that suppresses "DfE::Analytics::SendEvents" messages from our logit stacks.

The changes were made as these messages are considered unnecessary at present, and we send too many.

## Changes proposed in this pull request
Documentation update

## Guidance to review
The change can be seen in the test and prod logit logstash pipelines

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
