### PR TITLE
[2242] Add -o pipefail to konduit.sh

### DIFF
--- a/scripts/konduit.sh
+++ b/scripts/konduit.sh
@@ -12,7 +12,7 @@
 # Stop the script in case a command fails. Cleanup will still run
 # Fail when a variable is unexpectedly not set
 # If variable $VAR can be unset, use ${VAR:-} to provide a default "" value
-set -eu
+set -euo pipefail
 
 help() {
    echo


### PR DESCRIPTION
## Context
The simple set -eu doesn't prevent failure when commands are piped to each other

## Changes proposed in this pull request
Add -o pipefail to detect failure even when using a pipe

## Guidance to review
See explicit failure in https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/13265051999/job/37032437831

Try konduit with various commands and arguments:

- scripts/konduit.sh apply-staging -- psql
- scripts/konduit.sh apply-staging -- redis-cli
- scripts/konduit.sh -a apply-review-10343  -- redis-cli
- scripts/konduit.sh apply-review-10343 --  pg_dump -E utf8 --clean --compress=1 --if-exists --no-owner --verbose --no-password -f bak.gz
- scripts/konduit.sh -c -i bak.gz apply-review-10343 -- psql
- scripts/konduit.sh -t 120 -n bat-qa apply-review-10343 -- psql
- scripts/konduit.sh -k s189t01-gse-stg-inf-kv -d gse-staging get-school-experience-staging  -- psql
- scripts/konduit.sh -k s189t01-gse-stg-inf-kv -s s189t01-gse-stg-pg -d gse-staging get-school-experience-staging -- psql

## After merging
Keep an eye on database workflows

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
