### PR TITLE
Use aks-review in rsm for managed identity

### DIFF
--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -114,7 +114,7 @@
       "access-your-teaching-qualifications": ["review", "test", "preprod"],
       "apply-for-qualified-teacher-status": ["review", "development", "test", "preproduction"],
       "check-childrens-barred-list": ["review", "test", "preproduction"],
-      "refer-serious-misconduct": ["review","test","preprod"],
+      "refer-serious-misconduct": ["aks-review","test","preprod"],
       "teaching-record-system": ["dev", "test", "pre-production"]
     },
     "tv": {


### PR DESCRIPTION
<!-- Delete sections if not required -->
## Context
<!-- Why are we making this change? New feature? Bug fix? -->
RSM apps use aks-review as their review environment

## Changes proposed in this pull request
<!-- Describe briefly the technical implementation -->
<!-- Show any dependencies between pull requests, i.e. this must be merged before or after another -->
Modify the managed identity to reflect the correct environment

## Guidance to review
<!-- Show how this can be tested or evidence that it is working -->
Check the managed identity for rsm. It should use `aks-review`.

## Trello Card
https://trello.com/c/FWUebqgi

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
