### PR TITLE
fix: Adding to faq doc for OIDC

### DIFF
--- a/documentation/platform-faq.md
+++ b/documentation/platform-faq.md
@@ -46,7 +46,7 @@
   - The federated credential for this environment does not exist
   - The managed identity does not exist
   - The managed identity is not added to the Entra ID group
-  - The Entra ID group is missing the role assignement
+  - The Entra ID group is missing the resource group within role assignement scope
 
   The managed identity should be added to the relevant Entra ID group via the `add member` option. If you cannot select this, validate you are an owner. Being an owner is required to add the managed identity to the Entra ID group.
 


### PR DESCRIPTION
Adding to Doc as resource group being missing from the group role assignments can be an additional source of failure.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
