### PR TITLE
Add register early career teachers public to cpd managed identity

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -136,6 +136,7 @@
     "cpd": {
       "early-careers-framework": ["migration", "production", "sandbox"],
       "npq-registration": ["sandbox", "production"],
+      "register-early-career-teachers-public": ["migration", "production", "sandbox"],
       "teaching-school-hub-finder": ["sandbox","production"]
     },
     "git": {

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -101,6 +101,7 @@
     "cpd": {
       "early-careers-framework": ["review", "staging"],
       "npq-registration": ["review", "staging"],
+      "register-early-career-teachers-public": ["review", "staging"],
       "teaching-school-hub-finder": ["review", "staging"]
     },
     "git": {


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
<!-- Why are we making this change? New feature? Bug fix? -->
Migrate register-early-career-teachers-public workflows to use OIDC


## Changes proposed in this pull request
<!-- Describe briefly the technical implementation -->
<!-- Show any dependencies between pull requests, i.e. this must be merged before or after another -->
Create federated credentials for register-early-career-teachers-public for all environments


## Guidance to review
<!-- Show how this can be tested or evidence that it is working -->
Review the federated credentials created in test environment


## After merging
<!-- Any extra steps like: update other PR, apply manually, inform someone... -->
- Create secrets
- Update workflows in publish teacher training


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
