### PR TITLE
Upgrading the AKS dev cluster1 from 1.30.6 to 1.31.5

### DIFF
--- a/cluster/terraform_aks_cluster/config/development.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/development.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.30.6",
+  "kubernetes_version": "1.31.5",
   "default_node_pool": {
     "node_count": 1,
-    "orchestrator_version": "1.30.6"
+    "orchestrator_version": "1.31.5"
   },
   "node_pools": {
     "apps1": {
@@ -12,7 +12,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.30.6"
+      "orchestrator_version": "1.31.5"
     }
   },
   "admin_group_id": "f77b2daf-7ff4-4aa5-8138-cf983d0b4a18"

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -94,7 +94,7 @@ variable "lowpriority_app_replicas" {
 
 variable "kube_state_metrics_version" {
   type    = string
-  default = "2.13.0"
+  default = "2.14.0"
 }
 
 data "azurerm_client_config" "current" {}


### PR DESCRIPTION
## Context
There is a requirement to keep up with the Kubernetes releases for bug fixes and new functionality. Our clusters are currently on 1.30

## Changes proposed in this pull request
Upgrade the Kubernetes cluster from 1.30.6 to 1.31.5.
Test cluster configuration for kubernetes cluster, orchestrator version for all node pools from 1.30.6 to 1.31.5
## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card

## Trello Card
https://trello.com/c/Gb9zGC6R/2255-aks-upgrade-to-131
