### PR TITLE
Upgrading the AKS prod cluster from 1.30.6 to 1.31.5

### DIFF
--- a/cluster/terraform_aks_cluster/config/production.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/production.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.30.6",
+  "kubernetes_version": "1.31.5",
   "default_node_pool": {
     "node_count": 3,
-    "orchestrator_version": "1.30.6"
+    "orchestrator_version": "1.31.5"
   },
   "node_pools": {
     "apps1": {
@@ -13,7 +13,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.30.6"
+      "orchestrator_version": "1.31.5"
     }
   },
   "admin_group_id": "5b0f84de-54a8-481a-8689-f3c226597259",


### PR DESCRIPTION
## Context
There is a requirement to keep up with the Kubernetes releases for bug fixes and new functionality.

## Changes proposed in this pull request
Upgrade the Prod Kubernetes cluster from 1.30.6 to 1.31.5.
Test cluster configuration for kubernetes cluster, orchestrator version for all node pools from 1.30.6 to 1.31.5

## Checklist

- [x]  I have performed a self-review of my code, including formatting and typos
- [x]  I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x]  I have added the Devops label
- [x]  I have attached the pull request to the trello card


## Trello Card
https://trello.com/c/Gb9zGC6R/2255-aks-upgrade-to-131