### PR TITLE
Create tra2 identity for ftr service

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -154,7 +154,9 @@
       "check-childrens-barred-list": ["production"],
       "find-a-lost-trn": ["production"],
       "refer-serious-misconduct": ["production"],
-      "teaching-record-system": ["production"],
+      "teaching-record-system": ["production"]
+    },
+    "tra2": {
       "Find-Teachers-For-Research": ["production"]
     },
     "tv": {

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -119,7 +119,9 @@
       "check-childrens-barred-list": ["review", "test", "preproduction"],
       "find-a-lost-trn": ["development", "review", "test", "preproduction"],
       "refer-serious-misconduct": ["review","test","preprod"],
-      "teaching-record-system": ["dev", "test", "pre-production"],
+      "teaching-record-system": ["dev", "test", "pre-production"]
+    },
+    "tra2": {
       "Find-Teachers-For-Research": ["review", "development"]
     },
     "tv": {


### PR DESCRIPTION
## Context

Create tra2 identity for the ftr service wif, 
as a maximum of 20 federated identity credentials can be added
to an application or user-assigned managed identity.

## Changes proposed in this pull request
Update tfvars.json

## Guidance to review
make test|production terraform-plan

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
