### PR TITLE
Enable Single Sign-On for Grafana via AzureAD

### DIFF
--- a/cluster/terraform_kubernetes/.terraform.lock.hcl
+++ b/cluster/terraform_kubernetes/.terraform.lock.hcl
@@ -5,8 +5,6 @@ provider "registry.terraform.io/eppo/environment" {
   version     = "1.3.5"
   constraints = "1.3.5"
   hashes = [
-    "h1:1Af95/IhzW16rbX8kSApfrAi8vwc5+7uVbCeyVaGw2E=",
-    "h1:J0rtl6GrLyBKYz6PQ5BXsyYfjHbgMEoAHEQQ3u0vPBc=",
     "h1:pceowuRAKcjLd+g4noIJdX6CBIWavlM4BvRTsGfH0uQ=",
     "zh:00e7a6bf7f0f09cc4871d7f4fee2c943ce61c05b9802365a97703d6c2e63e3dc",
     "zh:018d92e621177d053ed5c32e8220efa8c019852c4d60cc7539683bac28470d9b",
@@ -26,13 +24,31 @@ provider "registry.terraform.io/eppo/environment" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/azuread" {
+  version     = "2.45.0"
+  constraints = "2.45.0"
+  hashes = [
+    "h1:/uvs5iEiakqbl4PEGzNob8Rqbnw7YaeXfjnTMfJJK2w=",
+    "zh:08d80f6ab1d8bcb02976a5fde0b108fc008093a7a6f1b5d083d5cf1e01dc0b86",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:2571a343d8e1af699c1e1d815a5654ad98665427c6f3912b41557ff775a73c75",
+    "zh:2a20afb34eaca73c2206250abbb40997498a1a9aca34e8d6524370fbf6278f82",
+    "zh:3044cb26396399f0082ee06a8f788c6260ab12e752f64c0d7921e7d4e39c14b8",
+    "zh:311fcfdee359129748caaae5b204113a3e3b7e1fc00704c21300461114eb2075",
+    "zh:a3af689267be6f7ebfd9726aa2bfd4faabb9efbcab9da24949ae5fec87d18d23",
+    "zh:adbe97fd77ef94c5f1fc8b10e7dc87048035dc39ff7ea81042350fc311034850",
+    "zh:c6ce4f348596515d1748c047b51462cb40802b57316b13f8fb4760ef1c5e775c",
+    "zh:d0b8854b5097ffd6f6d6a14544f74745b23ba949472351e585c57402f5ca28ae",
+    "zh:ebdf01510f10e468aaa6c8f5fd9fc50b7232acbbe5fcbc50e8bea2de5d964d3e",
+    "zh:f3a55da36dcfd0bf34f785ce3c47dbe8538408c1aaf729604a6ef841fc8ce6f4",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.116.0"
   constraints = "3.116.0"
   hashes = [
-    "h1:2QbjtN4oMXzdA++Nvrj/wSmWZTPgXKOSFGGQCLEMrb4=",
     "h1:BCR3NIorFSvGG3v/+JOiiw3VM4PkChLO4m84wzD9NDo=",
-    "h1:SJM/KQDW9blKFmLMaupsZVYtcZ0fYpjLHEriMgCBGCY=",
     "zh:02b6606aff025fc2a962b3e568e000300abe959adac987183c24dac8eb057f4d",
     "zh:2a23a8ce24ff9e885925ffee0c3ea7eadba7a702541d05869275778aa47bdea7",
     "zh:57d10746384baeca4d5c56e88872727cdc150f437b8c5e14f0542127f7475e24",
@@ -53,8 +69,6 @@ provider "registry.terraform.io/hashicorp/helm" {
   constraints = "2.15.0"
   hashes = [
     "h1:VymvscRkDy0+zN2uKpKYY6njXPY8JROARuaL3VPsEos=",
-    "h1:WfjJptfaDzC4XCht262FFizAMX8fvRDZWtqUmuLcg88=",
-    "h1:qPUoXPUCizzPS8tlJydH+VBXeiOeizOiSEOaNqZEyMY=",
     "zh:18b94c7c83c30ad166722a61a412e3de6a67935772960e79aaa24c15f8ea0d0f",
     "zh:4f07c929a71e8169f7471b7600bfcca36dfb295787e975e82ac0455a3ab68b47",
     "zh:776b804a14c3c4ae6075b12176f81c1f1987214ee1cae4a542599389591cde11",
@@ -75,8 +89,6 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   constraints = "2.32.0"
   hashes = [
     "h1:3j4XBR5UWQA7xXaiEnzZp0bHbcwOhWetHYKTWIrUTI0=",
-    "h1:Cj3RHyw3wE3AkNlCtSNrZfjFNkShvaZR0K/K3pJlYJU=",
-    "h1:HqeU0sZBh+2loFYqPMFx7jJamNUPEykyqJ9+CkMCYE0=",
     "zh:0e715d7fb13a8ad569a5fdc937b488590633f6942e986196fdb17cd7b8f7720e",
     "zh:495fc23acfe508ed981e60af9a3758218b0967993065e10a297fdbc210874974",
     "zh:4b930a8619910ef528bc90dae739cb4236b9b76ce41367281e3bc3cf586101c7",
@@ -96,9 +108,7 @@ provider "registry.terraform.io/statuscakedev/statuscake" {
   version     = "2.2.2"
   constraints = "2.2.2"
   hashes = [
-    "h1:OoqL/K/eNLahbfMwJvYZHo9kacafjtrJKhd6cLrubZ4=",
     "h1:nVaJkDBk4sv0yWFzg3p+yeJGzE8mB4KJv3Q6/UgU164=",
-    "h1:wFoZJfmNvG6XTf65NLai67geSHqYV1Tilx7OITrHilE=",
     "zh:0916313344c579d6e05d70f88129a10fe48f7dabe0e61cad17874d6c496f288d",
     "zh:0d491ff72c2eda6482855033ca2146c5ace1663d07cb3da7253b59ed2e2ec6f4",
     "zh:11fffbce18eb3d3c283e877242f477e0c561342c19090240b60af7d948bd84ac",

--- a/cluster/terraform_kubernetes/terraform.tf
+++ b/cluster/terraform_kubernetes/terraform.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "3.116.0"
     }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "2.45.0"
+    }
     environment = {
       source  = "EppO/environment"
       version = "1.3.5"
@@ -31,6 +35,9 @@ terraform {
 provider "azurerm" {
   features {}
   skip_provider_registration = true
+}
+
+provider "azuread" {
 }
 
 data "azurerm_kubernetes_cluster" "main" {

--- a/documentation/grafana.md
+++ b/documentation/grafana.md
@@ -1,0 +1,95 @@
+# Grafana Monitoring
+
+## Overview
+Grafana provides visualization and monitoring capabilities for our infrastructure and applications. Our Grafana instance is deployed in Kubernetes and secured with Azure AD authentication.
+
+## Authentication Architecture
+- Grafana is configured with Azure AD Single Sign-On
+- **Azure AD applications are created manually** (one per subscription)
+- Access is controlled through Azure AD application roles:
+  - **Admin**: Full access to create and edit dashboards, users, and settings
+  - **Editor**: Can create and edit dashboards but cannot manage users
+  - **Viewer**: Read-only access to dashboards
+
+## How to Access
+Access Grafana at: https://grafana.<CLUSTER-NAME-IF-PRESENT>.<ENVIRONMENT>.teacherservices.cloud
+
+## App Registration Configuration (Manual Setup)
+1. Create one app registration per subscription with naming pattern:
+   - `[subscription-id]-grafana` (e.g., `s189d01-grafana`)
+2. Configure Web platform with:
+   - Homepage URL: Any representative Grafana instance URL
+   - Redirect URIs: **Add all cluster URLs** in the subscription:
+     ```
+     https://grafana.cluster1.development.teacherservices.cloud/login/azuread
+     https://grafana.cluster1.development.teacherservices.cloud/
+     https://grafana.cluster2.development.teacherservices.cloud/login/azuread
+     https://grafana.cluster2.development.teacherservices.cloud/
+     ```
+   - Logout URL: Any representative Grafana login page
+3. Create app roles:
+   - Admin, Editor, and Viewer roles with exact values matching Grafana's expectations
+4. Create a client secret with description "Grafana OAuth 2.0"
+
+## Key Vault Setup (Manual)
+For each subscription, add these secrets to the appropriate Key Vault:
+- `GF-AZURE-CLIENT-ID`: The Application (client) ID of your app registration
+- `GRAFANA-AZURE-CLIENT-ID-SECRET`: The client secret value
+
+## Managing User Access
+1. Go to Azure Portal → Microsoft Entra ID → Enterprise Applications
+2. Find your application (e.g., `s189d01-grafana`)
+   - Note: The application may not appear until after first sign-in
+3. Navigate to "Users and groups"
+4. Assign users or groups to the appropriate role
+
+**Important Note**: Since the app registration is now created manually at the subscription level, redeploying individual clusters will **not** affect Azure AD group assignments. Group assignments only need to be set up once per subscription, not per cluster.
+
+## Local Development
+For local development or testing:
+```bash
+kubectl port-forward -n monitoring svc/grafana 3000:3000
+```
+Then access Grafana at http://localhost:3000
+
+## Infrastructure Configuration
+Grafana is deployed via Terraform in `cluster/terraform_kubernetes/grafana.tf`. Key components include:
+- References to manually created Azure AD application credentials from Key Vault
+- Kubernetes deployment with proper environment configuration
+- Ingress for external access
+
+## Environment Variables
+Grafana's behavior is configured through environment variables in the deployment:
+
+- **Authentication Configuration**:
+  - `GF_AUTH_AZUREAD_ENABLED`: Enables Azure AD authentication
+  - `GF_AUTH_AZUREAD_CLIENT_ID`: Application (client) ID from Key Vault
+  - `GF_AUTH_AZUREAD_CLIENT_SECRET`: Client secret from Key Vault
+  - `GF_AUTH_AZUREAD_SCOPES`: OAuth scopes (typically "openid email profile")
+  - `GF_AUTH_AZUREAD_ROLE_ATTRIBUTE_PATH`: Maps Azure AD roles to Grafana roles
+
+- **Security Settings**:
+  - `GF_AUTH_ANONYMOUS_ENABLED`: Set to "false" to require authentication
+  - `GF_AUTH_AZUREAD_USE_PKCE`: Enables PKCE for enhanced OAuth security
+  - `GF_AUTH_AZUREAD_ALLOWED_ORGANIZATIONS`: Restricts access to specific tenant
+
+- **Server Configuration**:
+  - `GF_SERVER_ROOT_URL`: External URL for Grafana (critical for proper asset loading)
+
+## Troubleshooting
+If you encounter issues with Grafana:
+
+1. **Authentication Problems**:
+   - Verify the manually created Azure AD application configuration in the Azure portal
+   - Ensure all cluster redirect URIs are added to the app registration
+   - Check that Key Vault contains the correct client ID and secret values
+   - Ensure client secret hasn't expired
+
+2. **UI Loading Issues**:
+   - Confirm `GF_SERVER_ROOT_URL` is set correctly
+   - Check ingress configuration and TLS settings
+
+3. **Role Assignment**:
+   - Verify users are assigned to the correct roles in Azure AD
+   - Check role attribute mapping configuration
+   - Remember the enterprise application may not appear until first sign-in


### PR DESCRIPTION
## Context

We need to implement secure authentication for our Grafana monitoring dashboard. Using Microsoft Entra ID (Azure AD) authentication allows us to leverage our existing identity provider for role-based access control, centralizing user management and enhancing security by eliminating anonymous access.

## Changes proposed in this pull request

- Created an Azure AD application registration for Grafana SSO with appropriate redirect URIs
- Configured three application roles (Admin, Editor, Viewer) for granular access control
- Updated Grafana deployment with comprehensive Azure AD authentication environment variables
- Disabled anonymous access to enforce authenticated sessions only
- Fixed ingress configuration to ensure proper frontend asset loading
- Implemented modern OAuth security practices including PKCE and proper scoping
- Added documentation for checking for debugging in case of needing to readd groups.

Dependencies: None - this PR is self-contained and can be deployed independently.

## Guidance to review

1. After deployment, navigate to https://grafana.cluster1.development.teacherservices.cloud or https://grafana.test.teacherservices.cloud
2. You should be redirected to Azure AD login
3. After authentication, verify you have appropriate permissions based on your assigned Azure AD role
4. Test that anonymous access is blocked by using an incognito window
5. Verify that the Grafana UI loads correctly with all assets

## Before merging

- Ensure the Azure AD application has been properly configured with redirect URIs
- Validate that user/group assignments have been made for at least one admin user
- No production downtime is expected, but consider merging outside of peak monitoring hours

## After merging

- Notify team that Grafana now requires Azure AD authentication
- Update documentation to reflect new login process and role assignment procedure
- Add administrators to the appropriate Azure AD role for ongoing Grafana management

NOTE: Role groups must be assigned after creation each time. This means if a cluster is destroyed the groups will be required to be readded. This could be avoided in future by separating out Azure related infra within application service folders.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
