### PR TITLE
fix: 2309-cluster-access-smoke-test: missing cluster name in slack alert

### DIFF
--- a/.github/workflows/cluster_access_test.yml
+++ b/.github/workflows/cluster_access_test.yml
@@ -77,7 +77,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_USERNAME: CI Deployment
-          SLACK_TITLE: Cluster Access Smoke Test FAILED for cluster ${{ env.cluster_name }}
+          SLACK_TITLE: "Cluster Access Smoke Test FAILED for cluster ${{ env.cluster_name }}"
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ALERTS }}
           SLACK_COLOR: failure
           SLACK_FOOTER: Sent from Cluster Access Smoke Test job in cluster_access_test workflow


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context: bug fix
<!-- Why are we making this change? New feature? Bug fix? -->

## Changes proposed in this pull request: fix missing cluster name in slack message
<!-- Describe briefly the technical implementation -->
<!-- Show any dependencies between pull requests, i.e. this must be merged before or after another -->

## Guidance to review: see recent alerts in #infra-alert-public
![Screenshot from 2025-04-30 13-27-56](https://github.com/user-attachments/assets/886e62fa-f9b0-4051-9099-f793c66c5f54)

<!-- Show how this can be tested or evidence that it is working -->

## Before merging
<!-- Any extra steps like: delete temp commit, send warning, wait after office hours... -->

## After merging
<!-- Any extra steps like: update other PR, apply manually, inform someone... -->

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
