### PR TITLE
Adding the alertmanager receiver config for capt

### DIFF
--- a/cluster/terraform_kubernetes/.terraform.lock.hcl
+++ b/cluster/terraform_kubernetes/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/eppo/environment" {
   version     = "1.3.5"
   constraints = "1.3.5"
   hashes = [
+    "h1:J0rtl6GrLyBKYz6PQ5BXsyYfjHbgMEoAHEQQ3u0vPBc=",
     "h1:pceowuRAKcjLd+g4noIJdX6CBIWavlM4BvRTsGfH0uQ=",
     "zh:00e7a6bf7f0f09cc4871d7f4fee2c943ce61c05b9802365a97703d6c2e63e3dc",
     "zh:018d92e621177d053ed5c32e8220efa8c019852c4d60cc7539683bac28470d9b",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/azuread" {
   version     = "2.45.0"
   constraints = "2.45.0"
   hashes = [
+    "h1:/LuV4Jyl+t/BZxRsIyuz2VRKPPFxH18FcO2xMnIWlUE=",
     "h1:/uvs5iEiakqbl4PEGzNob8Rqbnw7YaeXfjnTMfJJK2w=",
     "zh:08d80f6ab1d8bcb02976a5fde0b108fc008093a7a6f1b5d083d5cf1e01dc0b86",
     "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
@@ -49,6 +51,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "3.116.0"
   hashes = [
     "h1:BCR3NIorFSvGG3v/+JOiiw3VM4PkChLO4m84wzD9NDo=",
+    "h1:SJM/KQDW9blKFmLMaupsZVYtcZ0fYpjLHEriMgCBGCY=",
     "zh:02b6606aff025fc2a962b3e568e000300abe959adac987183c24dac8eb057f4d",
     "zh:2a23a8ce24ff9e885925ffee0c3ea7eadba7a702541d05869275778aa47bdea7",
     "zh:57d10746384baeca4d5c56e88872727cdc150f437b8c5e14f0542127f7475e24",
@@ -69,6 +72,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   constraints = "2.15.0"
   hashes = [
     "h1:VymvscRkDy0+zN2uKpKYY6njXPY8JROARuaL3VPsEos=",
+    "h1:WfjJptfaDzC4XCht262FFizAMX8fvRDZWtqUmuLcg88=",
     "zh:18b94c7c83c30ad166722a61a412e3de6a67935772960e79aaa24c15f8ea0d0f",
     "zh:4f07c929a71e8169f7471b7600bfcca36dfb295787e975e82ac0455a3ab68b47",
     "zh:776b804a14c3c4ae6075b12176f81c1f1987214ee1cae4a542599389591cde11",
@@ -89,6 +93,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   constraints = "2.32.0"
   hashes = [
     "h1:3j4XBR5UWQA7xXaiEnzZp0bHbcwOhWetHYKTWIrUTI0=",
+    "h1:HqeU0sZBh+2loFYqPMFx7jJamNUPEykyqJ9+CkMCYE0=",
     "zh:0e715d7fb13a8ad569a5fdc937b488590633f6942e986196fdb17cd7b8f7720e",
     "zh:495fc23acfe508ed981e60af9a3758218b0967993065e10a297fdbc210874974",
     "zh:4b930a8619910ef528bc90dae739cb4236b9b76ce41367281e3bc3cf586101c7",
@@ -108,6 +113,7 @@ provider "registry.terraform.io/statuscakedev/statuscake" {
   version     = "2.2.2"
   constraints = "2.2.2"
   hashes = [
+    "h1:OoqL/K/eNLahbfMwJvYZHo9kacafjtrJKhd6cLrubZ4=",
     "h1:nVaJkDBk4sv0yWFzg3p+yeJGzE8mB4KJv3Q6/UgU164=",
     "zh:0916313344c579d6e05d70f88129a10fe48f7dabe0e61cad17874d6c496f288d",
     "zh:0d491ff72c2eda6482855033ca2146c5ace1663d07cb3da7253b59ed2e2ec6f4",

--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -59,6 +59,7 @@
     "SLACK_WEBHOOK_PTT",
     "SLACK_WEBHOOK_CPD",
     "SLACK_WEBHOOK_RSM",
+    "SLACK_WEBHOOK_CAPT",
     "SLACK_WEBHOOK_GENERIC"
   ],
   "alertable_apps": {
@@ -124,6 +125,9 @@
     },
     "tra-production/refer-serious-misconduct-production-worker": {
       "receiver": "SLACK_WEBHOOK_RSM"
+    },
+    "srtl-production/claim-additional-payments-for-teaching-production": {
+      "receiver": "SLACK_WEBHOOK_CAPT"
     }
   },
   "ga_wif_managed_id": {

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -79,6 +79,9 @@
     },
     "bat-staging/publish-staging": {
       "receiver": "SLACK_WEBHOOK_PTT"
+    },
+    "srtl-test/claim-additional-payments-for-teaching-test": {
+      "receiver": "SLACK_WEBHOOK_CAPT"
     }
   },
   "alertmanager_slack_receiver_list": [
@@ -88,7 +91,8 @@
     "SLACK_WEBHOOK_GIT",
     "SLACK_WEBHOOK_ITTMS",
     "SLACK_WEBHOOK_PTT",
-    "SLACK_WEBHOOK_GENERIC"
+    "SLACK_WEBHOOK_GENERIC",
+    "SLACK_WEBHOOK_CAPT"
   ],
   "block_metrics_endpoint" : false,
   "ga_wif_managed_id": {


### PR DESCRIPTION
## Context
Adding the alertmanager receiver config for capt

## Changes proposed in this pull request
Adding the alertmanager receiver config for capt

## Guidance to review

make test terraform-kubernetes-plan CONFIRM_TEST=yes
make production terraform-kubernetes-plan CONFIRM_PRODUCTION=yes
receiver available in alertmanager UI
k port-forward alertmanager-7bcb4b54c6-429kf -n monitoring 9093:9093
```
  - receiver: SLACK_WEBHOOK_CAPT
    match:
      receiver: SLACK_WEBHOOK_CAPT
    continue: false
    group_interval: 1m
    repeat_interval: 1h
```


## Checklist
- [x]  I have performed a self-review of my code, including formatting and typos
- [x]  I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x]  I have added the Devops label
- [x]  I have attached the pull request to the trello card