### PR TITLE
 Adding the alertmanager receiver config for rotp

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -60,6 +60,7 @@
     "SLACK_WEBHOOK_CPD",
     "SLACK_WEBHOOK_RSM",
     "SLACK_WEBHOOK_CAPT",
+    "SLACK_WEBHOOK_ROTP",
     "SLACK_WEBHOOK_GENERIC"
   ],
   "alertable_apps": {
@@ -128,6 +129,9 @@
     },
     "srtl-production/claim-additional-payments-for-teaching-production": {
       "receiver": "SLACK_WEBHOOK_CAPT"
+    },
+    "bat-production/register-training-providers-production": {
+      "receiver": "SLACK_WEBHOOK_ROTP"
     }
   },
   "ga_wif_managed_id": {

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -82,6 +82,9 @@
     },
     "srtl-test/claim-additional-payments-for-teaching-test": {
       "receiver": "SLACK_WEBHOOK_CAPT"
+    },
+    "bat-staging/register-training-providers-staging": {
+      "receiver": "SLACK_WEBHOOK_ROTP"
     }
   },
   "alertmanager_slack_receiver_list": [
@@ -92,7 +95,8 @@
     "SLACK_WEBHOOK_ITTMS",
     "SLACK_WEBHOOK_PTT",
     "SLACK_WEBHOOK_GENERIC",
-    "SLACK_WEBHOOK_CAPT"
+    "SLACK_WEBHOOK_CAPT",
+    "SLACK_WEBHOOK_ROTP"
   ],
   "block_metrics_endpoint" : false,
   "ga_wif_managed_id": {


### PR DESCRIPTION
## Context
Adding the alertmanager receiver config for rotp

## Changes proposed in this pull request
Adding the alertmanager receiver config for rotp

## Guidance to review
make test terraform-kubernetes-plan CONFIRM_TEST=yes
make production terraform-kubernetes-plan CONFIRM_PRODUCTION=yes
receiver available in alertmanager UI

```
  - receiver: SLACK_WEBHOOK_ROTP
    match:
      receiver: SLACK_WEBHOOK_ROTP
    continue: false
    group_interval: 1m
    repeat_interval: 1h
```


## Checklist

- [x]  I have performed a self-review of my code, including formatting and typos
- [x]  I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x]  I have added the Devops label
- [x]  I have attached the pull request to the trello card