### PR TITLE
Increase test cluster apps1 nodepool max to 30

### DIFF
--- a/cluster/terraform_aks_cluster/config/test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/test.tfvars.json
@@ -8,7 +8,7 @@
   "node_pools": {
     "apps1": {
       "min_count": 2,
-      "max_count": 25,
+      "max_count": 30,
       "vm_size": "Standard_E4ads_v5",
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"


### PR DESCRIPTION
## Context
Test cluster apps1 nodepool is getting close to its current max size (25 nodes)

## Changes proposed in this pull request
Increase max size to 30 nodes

## Guidance to review
make test terraform-plan

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
