### PR TITLE
Adding the alertmanager receiver config for aytq

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -61,6 +61,7 @@
     "SLACK_WEBHOOK_RSM",
     "SLACK_WEBHOOK_CAPT",
     "SLACK_WEBHOOK_ROTP",
+    "SLACK_WEBHOOK_AYTQ",
     "SLACK_WEBHOOK_GENERIC"
   ],
   "alertable_apps": {
@@ -126,6 +127,9 @@
     },
     "tra-production/refer-serious-misconduct-production-worker": {
       "receiver": "SLACK_WEBHOOK_RSM"
+    },
+    "tra-production/access-your-teaching-qualifications-production": {
+      "receiver": "SLACK_WEBHOOK_AYTQ"
     },
     "srtl-production/claim-additional-payments-for-teaching-production": {
       "receiver": "SLACK_WEBHOOK_CAPT"

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -85,6 +85,9 @@
     },
     "bat-staging/register-training-providers-staging": {
       "receiver": "SLACK_WEBHOOK_ROTP"
+    },
+    "tra-test/access-your-teaching-qualifications-preprod": {
+      "receiver": "SLACK_WEBHOOK_AYTQ"
     }
   },
   "alertmanager_slack_receiver_list": [
@@ -96,7 +99,8 @@
     "SLACK_WEBHOOK_PTT",
     "SLACK_WEBHOOK_GENERIC",
     "SLACK_WEBHOOK_CAPT",
-    "SLACK_WEBHOOK_ROTP"
+    "SLACK_WEBHOOK_ROTP",
+    "SLACK_WEBHOOK_AYTQ"
   ],
   "block_metrics_endpoint" : false,
   "ga_wif_managed_id": {


### PR DESCRIPTION
## Context
Adding the alertmanager receiver config for aytq

## Changes proposed in this pull request
Adding the alertmanager receiver config for aytq

## Guidance to review
make test terraform-kubernetes-plan CONFIRM_TEST=yes
make production terraform-kubernetes-plan CONFIRM_PRODUCTION=yes
receiver available in alertmanager UI

```
  - receiver: SLACK_WEBHOOK_AYTQ
    match:
      receiver: SLACK_WEBHOOK_AYTQ
    continue: false
    group_interval: 1m
    repeat_interval: 1h
```
## Checklist
- [x]  I have performed a self-review of my code, including formatting and typos
- [x]  I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x]  I have added the Devops label
- [x]  I have attached the pull request to the trello cardContext
