### PR TITLE
Alerts configured for ecf prod and sandbox env for High Memory and CPU

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -122,6 +122,12 @@
     "cpd-production/cpd-tsh-production": {
       "receiver": "SLACK_WEBHOOK_CPD"
     },
+    "cpd-production/cpd-ecf-production": {
+      "receiver": "SLACK_WEBHOOK_CPD"
+    },
+    "cpd-production/cpd-ecf-sandbox": {
+      "receiver": "SLACK_WEBHOOK_CPD"
+    },
     "tra-production/refer-serious-misconduct-production": {
       "receiver": "SLACK_WEBHOOK_RSM"
     },


### PR DESCRIPTION
## Context
Alerts configured for ecf prod and sandbox env for High Memory and CPU
## Changes proposed in this pull request
Alerts configured for ecf prod and sandbox env for High Memory and CPU

## Guidance to review
make production terraform-kubernetes-plan CONFIRM_PRODUCTION=yes
Alerts available in Prometheus UI
k port-forward prometheus-557dd498c8-x2rw2 9090:9090 -n monitoring
http://localhost:9090/alerts?search=
look for cpd-ecf alerts

## Checklist
- [x]  I have performed a self-review of my code, including formatting and typos
- [x]  I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x]  I have added the Devops label
- [x]  I have attached the pull request to the trello card