### PR TITLE
Alerts configured for ec2

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -128,6 +128,12 @@
     "cpd-production/cpd-ecf-sandbox": {
       "receiver": "SLACK_WEBHOOK_CPD"
     },
+    "cpd-production/cpd-ec2-sandbox": {
+      "receiver": "SLACK_WEBHOOK_CPD"
+    },
+    "cpd-production/cpd-ec2-production": {
+      "receiver": "SLACK_WEBHOOK_CPD"
+    },
     "tra-production/refer-serious-misconduct-production": {
       "receiver": "SLACK_WEBHOOK_RSM"
     },

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -65,6 +65,9 @@
     "bat-staging/register-staging": {
       "receiver": "SLACK_WEBHOOK_RTT"
     },
+    "cpd-development/cpd-ec2-staging": {
+      "receiver": "SLACK_WEBHOOK_CPD"
+    },
     "git-test/get-school-experience-staging": {
       "receiver": "SLACK_WEBHOOK_GSE"
     },
@@ -92,6 +95,7 @@
   },
   "alertmanager_slack_receiver_list": [
     "SLACK_WEBHOOK_ATT",
+    "SLACK_WEBHOOK_CPD",
     "SLACK_WEBHOOK_RTT",
     "SLACK_WEBHOOK_GSE",
     "SLACK_WEBHOOK_GIT",


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
Alerts need to be configured for ec2 staging, prod and sandbox env for High Memory and CPU



## Changes proposed in this pull request
Add configuration to create alerts

## Guidance to review
Alerts should be visible in prometheus ui

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
