### PR TITLE
Memory limit increased to 0.9 for prometheus alert

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -150,7 +150,8 @@
       "receiver": "SLACK_WEBHOOK_GENERIC"
     },
     "monitoring/prometheus": {
-      "receiver": "SLACK_WEBHOOK_GENERIC"
+      "receiver": "SLACK_WEBHOOK_GENERIC",
+      "max_mem": "0.9"
     },
     "monitoring/alertmanager": {
       "receiver": "SLACK_WEBHOOK_GENERIC"

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -96,7 +96,8 @@
       "receiver": "SLACK_WEBHOOK_GENERIC"
     },
     "monitoring/prometheus": {
-      "receiver": "SLACK_WEBHOOK_GENERIC"
+      "receiver": "SLACK_WEBHOOK_GENERIC",
+      "max_mem": "0.9"
     },
     "monitoring/alertmanager": {
       "receiver": "SLACK_WEBHOOK_GENERIC"


### PR DESCRIPTION
## Context
Memory limit increased to 0.9 for prometheus alert

## Changes proposed in this pull request
Memory limit increased to 0.9 for prometheus alert

## Guidance to review
make production terraform-kubernetes-plan CONFIRM_PRODUCTION=yes
Alert memory limit available in Prometheus UI

## Checklist

- [x]  I have performed a self-review of my code, including formatting and typos
- [x]  I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x]  I have added the Devops label
- [x]  I have attached the pull request to the trello card