### PR TITLE
Amending the slack webhook and Increasing the memory limit for prometheus

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -150,7 +150,7 @@
       "receiver": "SLACK_WEBHOOK_GENERIC"
     },
     "monitoring/prometheus": {
-      "receiver": "SLACK_WEBHOOK_GENERIC",
+      "receiver": "SLACK_WEBHOOK_INFRA",
       "max_mem": "0.9"
     },
     "monitoring/alertmanager": {

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -48,7 +48,7 @@
   "enable_lowpriority_app": true,
   "lowpriority_app_cpu": "0.5",
   "lowpriority_app_mem": "1Gi",
-  "prometheus_app_mem": "14Gi",
+  "prometheus_app_mem": "16Gi",
   "prometheus_app_cpu": "0.5",
   "thanos_querier_mem": "2Gi",
   "thanos_store_mem": "5Gi",
@@ -96,7 +96,7 @@
       "receiver": "SLACK_WEBHOOK_GENERIC"
     },
     "monitoring/prometheus": {
-      "receiver": "SLACK_WEBHOOK_GENERIC",
+      "receiver": "SLACK_WEBHOOK_INFRA",
       "max_mem": "0.9"
     },
     "monitoring/alertmanager": {


### PR DESCRIPTION
## Context
Amending the slack webhook and Increasing the memory limit for prometheus

## Changes proposed in this pull request
Amending the slack webhook and Increasing the memory limit for prometheus

## Guidance to review
memory limit increased for test prometheus
Slack webhook added for #infra-alert-public

## Checklist
- [x]  I have performed a self-review of my code, including formatting and typos
- [x]  I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x]  I have added the Devops label
- [x]  I have attached the pull request to the trello card
