### PR TITLE
feat(2354): added deployment monitoring webhook for CTP

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -62,6 +62,7 @@
     "SLACK_WEBHOOK_CAPT",
     "SLACK_WEBHOOK_ROTP",
     "SLACK_WEBHOOK_AYTQ",
+    "SLACK_WEBHOOK_CTP",
     "SLACK_WEBHOOK_GENERIC"
   ],
   "alertable_apps": {
@@ -139,6 +140,9 @@
     },
     "srtl-production/claim-additional-payments-for-teaching-production": {
       "receiver": "SLACK_WEBHOOK_CAPT"
+    },
+    "srtl-production/teacher-pay-calculator-production": {
+      "receiver": "SLACK_WEBHOOK_CTP"
     },
     "bat-production/register-training-providers-production": {
       "receiver": "SLACK_WEBHOOK_ROTP"

--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -141,7 +141,7 @@
     "srtl-production/claim-additional-payments-for-teaching-production": {
       "receiver": "SLACK_WEBHOOK_CAPT"
     },
-    "srtl-production/teacher-pay-calculator-production": {
+    "srtl-production/calculate-teacher-pay-production": {
       "receiver": "SLACK_WEBHOOK_CTP"
     },
     "bat-production/register-training-providers-production": {

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -83,9 +83,6 @@
     "srtl-test/claim-additional-payments-for-teaching-test": {
       "receiver": "SLACK_WEBHOOK_CAPT"
     },
-    "srtl-development/calculate-teacher-pay-development": {
-      "receiver": "SLACK_WEBHOOK_CTP"
-    },
     "bat-staging/register-training-providers-staging": {
       "receiver": "SLACK_WEBHOOK_ROTP"
     },
@@ -116,8 +113,7 @@
     "SLACK_WEBHOOK_GENERIC",
     "SLACK_WEBHOOK_CAPT",
     "SLACK_WEBHOOK_ROTP",
-    "SLACK_WEBHOOK_AYTQ",
-    "SLACK_WEBHOOK_CTP"
+    "SLACK_WEBHOOK_AYTQ"
   ],
   "block_metrics_endpoint" : false,
   "ga_wif_managed_id": {

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -83,7 +83,7 @@
     "srtl-test/claim-additional-payments-for-teaching-test": {
       "receiver": "SLACK_WEBHOOK_CAPT"
     },
-    "srtl-test/teacher-pay-calculator-test": {
+    "srtl-development/calculate-teacher-pay-development": {
       "receiver": "SLACK_WEBHOOK_CTP"
     },
     "bat-staging/register-training-providers-staging": {

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -83,6 +83,9 @@
     "srtl-test/claim-additional-payments-for-teaching-test": {
       "receiver": "SLACK_WEBHOOK_CAPT"
     },
+    "srtl-test/teacher-pay-calculator-test": {
+      "receiver": "SLACK_WEBHOOK_CTP"
+    },
     "bat-staging/register-training-providers-staging": {
       "receiver": "SLACK_WEBHOOK_ROTP"
     },
@@ -113,7 +116,8 @@
     "SLACK_WEBHOOK_GENERIC",
     "SLACK_WEBHOOK_CAPT",
     "SLACK_WEBHOOK_ROTP",
-    "SLACK_WEBHOOK_AYTQ"
+    "SLACK_WEBHOOK_AYTQ",
+    "SLACK_WEBHOOK_CTP"
   ],
   "block_metrics_endpoint" : false,
   "ga_wif_managed_id": {


### PR DESCRIPTION
## Context
Adding the alertmanager receiver config for CTP

## Changes proposed in this pull request
Adding the alertmanager receiver config for CTP

## Guidance to review

make test terraform-kubernetes-plan CONFIRM_TEST=yes
make production terraform-kubernetes-plan CONFIRM_PRODUCTION=yes
receiver available in alertmanager UI
k port-forward alertmanager-7bcb4b54c6-429kf -n monitoring 9093:9093
```
  - receiver: SLACK_WEBHOOK_CTP
    match:
      receiver: SLACK_WEBHOOK_CTP
    continue: false
    group_interval: 1m
    repeat_interval: 1h
```


## Checklist
- [x]  I have performed a self-review of my code, including formatting and typos
- [x]  I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x]  I have added the Devops label
- [x]  I have attached the pull request to the trello card
