### PR TITLE
tune prometheus alerting

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -63,6 +63,7 @@
     "SLACK_WEBHOOK_ROTP",
     "SLACK_WEBHOOK_AYTQ",
     "SLACK_WEBHOOK_CTP",
+    "SLACK_WEBHOOK_INFRA",
     "SLACK_WEBHOOK_GENERIC"
   ],
   "alertable_apps": {
@@ -154,17 +155,17 @@
       "receiver": "SLACK_WEBHOOK_ROTP"
     },
     "monitoring/grafana": {
-      "receiver": "SLACK_WEBHOOK_GENERIC"
+      "receiver": "SLACK_WEBHOOK_INFRA"
     },
     "monitoring/thanos": {
-      "receiver": "SLACK_WEBHOOK_GENERIC"
+      "receiver": "SLACK_WEBHOOK_INFRA"
     },
     "monitoring/prometheus": {
       "receiver": "SLACK_WEBHOOK_INFRA",
-      "max_mem": "0.9"
+      "max_mem": "0.99"
     },
     "monitoring/alertmanager": {
-      "receiver": "SLACK_WEBHOOK_GENERIC"
+      "receiver": "SLACK_WEBHOOK_INFRA"
     },
     "common-production/teacher-services-tech-docs": {
       "receiver": "SLACK_WEBHOOK_GENERIC"

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -48,7 +48,7 @@
   "enable_lowpriority_app": true,
   "lowpriority_app_cpu": "0.5",
   "lowpriority_app_mem": "1Gi",
-  "prometheus_app_mem": "16Gi",
+  "prometheus_app_mem": "17Gi",
   "prometheus_app_cpu": "0.5",
   "thanos_querier_mem": "2Gi",
   "thanos_store_mem": "5Gi",
@@ -96,17 +96,17 @@
       "receiver": "SLACK_WEBHOOK_AYTQ"
     },
     "monitoring/grafana": {
-      "receiver": "SLACK_WEBHOOK_GENERIC"
+      "receiver": "SLACK_WEBHOOK_INFRA"
     },
     "monitoring/thanos": {
-      "receiver": "SLACK_WEBHOOK_GENERIC"
+      "receiver": "SLACK_WEBHOOK_INFRA"
     },
     "monitoring/prometheus": {
       "receiver": "SLACK_WEBHOOK_INFRA",
-      "max_mem": "0.9"
+      "max_mem": "0.99"
     },
     "monitoring/alertmanager": {
-      "receiver": "SLACK_WEBHOOK_GENERIC"
+      "receiver": "SLACK_WEBHOOK_INFRA"
     }
   },
   "alertmanager_slack_receiver_list": [
@@ -120,7 +120,8 @@
     "SLACK_WEBHOOK_GENERIC",
     "SLACK_WEBHOOK_CAPT",
     "SLACK_WEBHOOK_ROTP",
-    "SLACK_WEBHOOK_AYTQ"
+    "SLACK_WEBHOOK_AYTQ",
+    "SLACK_WEBHOOK_INFRA"
   ],
   "block_metrics_endpoint" : false,
   "ga_wif_managed_id": {


### PR DESCRIPTION
## Context
Prometheus monitoring is noisy and some tuning required

## Changes proposed in this pull request
- increase test prometheus to 17G
- increase prometheus memory threshold to 99%
- move all prometheus/grafana/thanos/alertmanager alerts to the separate infra channel

## Guidance to review
make test|prod terraform-plan

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
