### PR TITLE
Increase test prometheus memory to 18G

### DIFF
--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -48,7 +48,7 @@
   "enable_lowpriority_app": true,
   "lowpriority_app_cpu": "0.5",
   "lowpriority_app_mem": "1Gi",
-  "prometheus_app_mem": "17Gi",
+  "prometheus_app_mem": "18Gi",
   "prometheus_app_cpu": "0.5",
   "thanos_querier_mem": "2Gi",
   "thanos_store_mem": "5Gi",


### PR DESCRIPTION
## Context
test cluster prometheus failing with OOM

## Changes proposed in this pull request
Increase memory from 17G to 18G

## Guidance to review
make test terraform-kubernetes-plan (already applied)

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
