### PR TITLE
Correct CPD deployment names for alerting

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -152,7 +152,10 @@
     "cpd-production/cpd-ec2-sandbox": {
       "receiver": "SLACK_WEBHOOK_CPD"
     },
-    "cpd-production/cpd-ec2-production": {
+    "cpd-production/cpd-ec2-production-web": {
+      "receiver": "SLACK_WEBHOOK_CPD"
+    },
+    "cpd-production/cpd-ec2-production-worker": {
       "receiver": "SLACK_WEBHOOK_CPD"
     },
     "tra-production/refer-serious-misconduct-production": {

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -77,7 +77,7 @@
     "bat-staging/register-staging": {
       "receiver": "SLACK_WEBHOOK_RTT"
     },
-    "cpd-development/cpd-ec2-staging": {
+    "cpd-development/cpd-ec2-staging-web": {
       "receiver": "SLACK_WEBHOOK_CPD"
     },
     "git-test/get-school-experience-staging": {


### PR DESCRIPTION
## Context

Correcting deployment name for CPD EC2

## Guidance to review

<img width="1114" alt="Screenshot 2025-07-09 at 14 05 49" src="https://github.com/user-attachments/assets/b712800c-23b3-40ad-ad92-5f7af2f76c9e" />

## After merging

Ensure pipelines run successfuly

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
