### PR TITLE
Correct deployment names

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -104,7 +104,10 @@
     "bat-production/itt-mentor-services-sandbox": {
       "receiver": "SLACK_WEBHOOK_ITTMS"
     },
-    "tra-production/apply-for-qts-production": {
+    "tra-production/apply-for-qts-production-web": {
+      "receiver": "SLACK_WEBHOOK_AFQT"
+    },
+    "tra-production/apply-for-qts-production-worker": {
       "receiver": "SLACK_WEBHOOK_AFQT"
     },
     "tra-production/trs-production-api": {
@@ -143,13 +146,22 @@
     "cpd-production/cpd-tsh-production": {
       "receiver": "SLACK_WEBHOOK_CPD"
     },
-    "cpd-production/cpd-ecf-production": {
+    "cpd-production/cpd-ecf-production-web": {
       "receiver": "SLACK_WEBHOOK_CPD"
     },
-    "cpd-production/cpd-ecf-sandbox": {
+    "cpd-production/cpd-ecf-production-worker": {
       "receiver": "SLACK_WEBHOOK_CPD"
     },
-    "cpd-production/cpd-ec2-sandbox": {
+    "cpd-production/cpd-ecf-sandbox-web": {
+      "receiver": "SLACK_WEBHOOK_CPD"
+    },
+    "cpd-production/cpd-ecf-sandbox-worker": {
+      "receiver": "SLACK_WEBHOOK_CPD"
+    },
+    "cpd-production/cpd-ec2-sandbox-web": {
+      "receiver": "SLACK_WEBHOOK_CPD"
+    },
+    "cpd-production/cpd-ec2-sandbox-worker": {
       "receiver": "SLACK_WEBHOOK_CPD"
     },
     "cpd-production/cpd-ec2-production-web": {
@@ -167,7 +179,7 @@
     "tra-production/access-your-teaching-qualifications-production": {
       "receiver": "SLACK_WEBHOOK_AYTQ"
     },
-    "srtl-production/claim-additional-payments-for-teaching-production": {
+    "srtl-production/claim-additional-payments-for-teaching-production-web": {
       "receiver": "SLACK_WEBHOOK_CAPT"
     },
     "srtl-production/calculate-teacher-pay-production": {
@@ -179,7 +191,13 @@
     "monitoring/grafana": {
       "receiver": "SLACK_WEBHOOK_INFRA"
     },
-    "monitoring/thanos": {
+    "monitoring/thanos-compactor": {
+      "receiver": "SLACK_WEBHOOK_INFRA"
+    },
+    "monitoring/thanos-querier": {
+      "receiver": "SLACK_WEBHOOK_INFRA"
+    },
+    "monitoring/thanos-store-gateway": {
       "receiver": "SLACK_WEBHOOK_INFRA"
     },
     "monitoring/prometheus": {

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -95,7 +95,7 @@
     "bat-staging/publish-staging": {
       "receiver": "SLACK_WEBHOOK_PTT"
     },
-    "srtl-test/claim-additional-payments-for-teaching-test": {
+    "srtl-test/claim-additional-payments-for-teaching-test-web": {
       "receiver": "SLACK_WEBHOOK_CAPT"
     },
     "bat-staging/register-training-providers-staging": {
@@ -104,16 +104,22 @@
     "tra-test/access-your-teaching-qualifications-preprod": {
       "receiver": "SLACK_WEBHOOK_AYTQ"
     },
-    "tra-test/apply-for-qts-test": {
+    "tra-test/apply-for-qts-test-web": {
       "receiver": "SLACK_WEBHOOK_AFQT"
     },
-    "tra-test/apply-for-qts-preproduction": {
+    "tra-test/apply-for-qts-preproduction-web": {
       "receiver": "SLACK_WEBHOOK_AFQT"
     },
     "monitoring/grafana": {
       "receiver": "SLACK_WEBHOOK_INFRA"
     },
-    "monitoring/thanos": {
+    "monitoring/thanos-compactor": {
+      "receiver": "SLACK_WEBHOOK_INFRA"
+    },
+    "monitoring/thanos-querier": {
+      "receiver": "SLACK_WEBHOOK_INFRA"
+    },
+    "monitoring/thanos-store-gateway": {
       "receiver": "SLACK_WEBHOOK_INFRA"
     },
     "monitoring/prometheus": {


### PR DESCRIPTION
## Context

Need to correct deployment names so that they can be picked by by the alertmanager app rule templates correctly.

## Changes proposed in this pull request

Adding the full deployment names for this which are ambiguous


## Guidance to review

## Before merging

Check app templates render with correct values using -
`make production terraform-kubernetes-plan CONFIRM_PRODUCTION=yes` locally

## After merging

Validate pipeline runs

## Checklist

- [X] I have performed a self-review of my code, including formatting and typos
- [X] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [X] I have added the `Devops` label