### PR TITLE
Increase prometheus memory to 21G

### DIFF
--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -57,7 +57,7 @@
   "enable_lowpriority_app": true,
   "lowpriority_app_cpu": "0.5",
   "lowpriority_app_mem": "1Gi",
-  "prometheus_app_mem": "19Gi",
+  "prometheus_app_mem": "21Gi",
   "prometheus_app_cpu": "0.5",
   "thanos_querier_mem": "2Gi",
   "thanos_store_mem": "5Gi",


### PR DESCRIPTION
## Context
prometheus deployment in test requires more memory

## Changes proposed in this pull request
Increase from 19G to 21G

## Guidance to review
make test terraform-kubernetes-plan (already deployed manually)

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
