### PR TITLE
chore(prom thanos-compactor amended alerting): cpu alertmanager threshold increase

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -192,7 +192,8 @@
       "receiver": "SLACK_WEBHOOK_INFRA"
     },
     "monitoring/thanos-compactor": {
-      "receiver": "SLACK_WEBHOOK_INFRA"
+      "receiver": "SLACK_WEBHOOK_INFRA",
+       "max_cpu": "0.99"
     },
     "monitoring/thanos-querier": {
       "receiver": "SLACK_WEBHOOK_INFRA"

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -114,7 +114,8 @@
       "receiver": "SLACK_WEBHOOK_INFRA"
     },
     "monitoring/thanos-compactor": {
-      "receiver": "SLACK_WEBHOOK_INFRA"
+      "receiver": "SLACK_WEBHOOK_INFRA",
+       "max_cpu": "0.99"
     },
     "monitoring/thanos-querier": {
       "receiver": "SLACK_WEBHOOK_INFRA"


### PR DESCRIPTION
# chore(prom thanos-compactor amended alerting): cpu alertmanager threshold increase

<!-- Delete sections if not required -->

## Context
receiving high cpu alerts in #infra-public-alert slack channel for thanos-compactor

## Changes proposed in this pull request
- increase alertmanager max_cpu threshold from 0.8 to 0.99 for thanos_compactor

## Guidance to review
<img width="557" height="210" alt="Screenshot from 2025-07-14 11-54-20" src="https://github.com/user-attachments/assets/641d57f5-377a-4c19-82b8-dc755b56fb8f" />
<img width="1652" height="235" alt="Screenshot from 2025-07-14 11-53-58" src="https://github.com/user-attachments/assets/7e4237f5-c056-43fa-9816-ca03cd7c7286" />





## Before merging
<!-- Any extra steps like: delete temp commit, send warning, wait after office hours... -->

## After merging
<!-- Any extra steps like: update other PR, apply manually, inform someone... -->

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
