### PR TITLE
feat(prometheus): reduce nginx ingress cardinality

### DIFF
--- a/cluster/terraform_kubernetes/config/prometheus/development.prometheus.yml
+++ b/cluster/terraform_kubernetes/config/prometheus/development.prometheus.yml
@@ -82,6 +82,10 @@ scrape_configs:
     - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
       action: keep
       regex: true
+    # Exclude nginx ingress pods from this job (they have their own job below)
+    - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+      action: drop
+      regex: ingress-nginx
     - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
       action: replace
       target_label: __metrics_path__
@@ -101,6 +105,48 @@ scrape_configs:
       target_label: kubernetes_pod_name
     - source_labels: [__meta_kubernetes_pod_node_name]
       target_label: nodename
+# Dedicated scrape config for nginx ingress with cardinality reduction
+  - job_name: 'nginx-ingress'
+    kubernetes_sd_configs:
+    - role: pod
+    relabel_configs:
+    - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+      action: keep
+      regex: ingress-nginx
+    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+      action: keep
+      regex: true
+    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+      action: replace
+      target_label: __metrics_path__
+      regex: (.+)
+    - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+      action: replace
+      regex: ([^:]+)(?::\d+)?;(\d+)
+      replacement: $1:$2
+      target_label: __address__
+    metric_relabel_configs:
+    # Drop specific labels from all nginx ingress histogram bucket metrics for cardinality reduction
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: instance
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: kubernetes_pod_name
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: pod_template_hash
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: controller_pod
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: nodename
+      replacement: ''
 # Scrape config for kube-state-metrics.
   - job_name: 'kube-state-metrics'
     static_configs:

--- a/cluster/terraform_kubernetes/config/prometheus/platform-test.prometheus.yml
+++ b/cluster/terraform_kubernetes/config/prometheus/platform-test.prometheus.yml
@@ -82,6 +82,10 @@ scrape_configs:
     - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
       action: keep
       regex: true
+    # Exclude nginx ingress pods from this job (they have their own job below)
+    - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+      action: drop
+      regex: ingress-nginx
     - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
       action: replace
       target_label: __metrics_path__
@@ -101,6 +105,48 @@ scrape_configs:
       target_label: kubernetes_pod_name
     - source_labels: [__meta_kubernetes_pod_node_name]
       target_label: nodename
+# Dedicated scrape config for nginx ingress with cardinality reduction
+  - job_name: 'nginx-ingress'
+    kubernetes_sd_configs:
+    - role: pod
+    relabel_configs:
+    - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+      action: keep
+      regex: ingress-nginx
+    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+      action: keep
+      regex: true
+    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+      action: replace
+      target_label: __metrics_path__
+      regex: (.+)
+    - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+      action: replace
+      regex: ([^:]+)(?::\d+)?;(\d+)
+      replacement: $1:$2
+      target_label: __address__
+    metric_relabel_configs:
+    # Drop specific labels from all nginx ingress histogram bucket metrics for cardinality reduction
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: instance
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: kubernetes_pod_name
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: pod_template_hash
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: controller_pod
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: nodename
+      replacement: ''
 # Scrape config for kube-state-metrics.
   - job_name: 'kube-state-metrics'
     static_configs:

--- a/cluster/terraform_kubernetes/config/prometheus/test.prometheus.yml
+++ b/cluster/terraform_kubernetes/config/prometheus/test.prometheus.yml
@@ -82,6 +82,10 @@ scrape_configs:
     - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
       action: keep
       regex: true
+    # Exclude nginx ingress pods from this job (they have their own job below)
+    - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+      action: drop
+      regex: ingress-nginx
     - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
       action: replace
       target_label: __metrics_path__
@@ -101,6 +105,48 @@ scrape_configs:
       target_label: kubernetes_pod_name
     - source_labels: [__meta_kubernetes_pod_node_name]
       target_label: nodename
+# Dedicated scrape config for nginx ingress with cardinality reduction
+  - job_name: 'nginx-ingress'
+    kubernetes_sd_configs:
+    - role: pod
+    relabel_configs:
+    - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+      action: keep
+      regex: ingress-nginx
+    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+      action: keep
+      regex: true
+    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+      action: replace
+      target_label: __metrics_path__
+      regex: (.+)
+    - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+      action: replace
+      regex: ([^:]+)(?::\d+)?;(\d+)
+      replacement: $1:$2
+      target_label: __address__
+    metric_relabel_configs:
+    # Drop specific labels from all nginx ingress histogram bucket metrics for cardinality reduction
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: instance
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: kubernetes_pod_name
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: pod_template_hash
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: controller_pod
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: nodename
+      replacement: ''
 # Scrape config for kube-state-metrics.
   - job_name: 'kube-state-metrics'
     static_configs:


### PR DESCRIPTION
  - Add dedicated nginx-ingress scrape job with metric relabeling
  - Drop high-cardinality labels from nginx_ingress_controller_.*_bucket metrics
  - Remove instance, kubernetes_pod_name, pod_template_hash, controller_pod, nodename labels
  - Preserve essential monitoring labels (ingress, service, method, status, le)
  - Exclude nginx pods from general kubernetes-pods job to prevent double-scraping
  - Add documentation capturing changes and affected metrics

  Reduces cardinality from 1.5m+ to manageable levels while
  maintaining service-level monitoring capabilities.

## Guidance to review

You can compare the total series between cluster2 and cluster6 to see the reduced series across all nginx bucket histogram metrics

https://prometheus.cluster2.development.teacherservices.cloud/graph?g0.expr=count(nginx_ingress_controller_response_size_bucket)&g0.tab=0&g0.display_mode=lines&g0.show_exemplars=0&g0.range_input=1h

https://prometheus.cluster6.development.teacherservices.cloud/graph?g0.expr=count(nginx_ingress_controller_response_size_bucket)&g0.tab=0&g0.display_mode=lines&g0.show_exemplars=0&g0.range_input=1h


## After merging

Validate prometheus is up and running correctly via logs and validate metric reduction from current total series for production and test. 

Test:

<img width="1380" height="571" alt="Screenshot 2025-07-22 at 21 38 12" src="https://github.com/user-attachments/assets/ccecace4-01c2-44f7-bbd2-2bd8377e6c1b" />

Prod:

<img width="1380" height="571" alt="Screenshot 2025-07-22 at 21 37 59" src="https://github.com/user-attachments/assets/2e669afe-fe98-4041-ae73-fe04512c1ce7" />

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
