### PR TITLE
Label drop production cluster metrics

### DIFF
--- a/cluster/terraform_kubernetes/config/prometheus/production.prometheus.yml
+++ b/cluster/terraform_kubernetes/config/prometheus/production.prometheus.yml
@@ -82,6 +82,10 @@ scrape_configs:
     - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
       action: keep
       regex: true
+    # Exclude nginx ingress pods from this job (they have their own job below)
+    - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+      action: drop
+      regex: ingress-nginx
     - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
       action: replace
       target_label: __metrics_path__
@@ -101,6 +105,75 @@ scrape_configs:
       target_label: kubernetes_pod_name
     - source_labels: [__meta_kubernetes_pod_node_name]
       target_label: nodename
+# Dedicated scrape config for nginx ingress with cardinality reduction
+  - job_name: 'nginx-ingress'
+    kubernetes_sd_configs:
+    - role: pod
+    relabel_configs:
+    - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+      action: keep
+      regex: ingress-nginx
+    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+      action: keep
+      regex: true
+    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+      action: replace
+      target_label: __metrics_path__
+      regex: (.+)
+    - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+      action: replace
+      regex: ([^:]+)(?::\d+)?;(\d+)
+      replacement: $1:$2
+      target_label: __address__
+    metric_relabel_configs:
+    # Drop specific labels from all nginx ingress histogram bucket metrics for cardinality reduction
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: instance
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: kubernetes_pod_name
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: pod_template_hash
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: controller_pod
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_.*_bucket
+      target_label: nodename
+      replacement: ''
+    
+    # Drop the orphan_ingress metric entirely
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_orphan_ingress
+      action: drop
+    
+    # For non-histogram metrics (count, sum, requests), drop high-cardinality labels
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_(request_size_count|request_size_sum|request_duration_seconds_count|bytes_sent_sum|requests)
+      target_label: instance
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_(request_size_count|request_size_sum|request_duration_seconds_count|bytes_sent_sum|requests)
+      target_label: kubernetes_pod_name
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_(request_size_count|request_size_sum|request_duration_seconds_count|bytes_sent_sum|requests)
+      target_label: pod_template_hash
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_(request_size_count|request_size_sum|request_duration_seconds_count|bytes_sent_sum|requests)
+      target_label: controller_pod
+      replacement: ''
+    - source_labels: [__name__]
+      regex: nginx_ingress_controller_(request_size_count|request_size_sum|request_duration_seconds_count|bytes_sent_sum|requests)
+      target_label: nodename
+      replacement: ''
 # Scrape config for kube-state-metrics.
   - job_name: 'kube-state-metrics'
     static_configs:


### PR DESCRIPTION
## Context

Applying label drops to production

## Changes proposed in this pull request

Same as for test and platform-test extended to k8s.

## After merging

Validate metrics have dropped and Prometheus is using less memory

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
