### PR TITLE
2461 aks deployment memory

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -47,7 +47,7 @@
   ],
   "ingress_nginx_version": "4.11.5",
   "enable_lowpriority_app": true,
-  "prometheus_app_mem": "16Gi",
+  "prometheus_app_mem": "14Gi",
   "prometheus_app_cpu": "0.5",
   "thanos_querier_mem": "2Gi",
   "thanos_app_cpu": "0.5",

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -57,7 +57,7 @@
   "enable_lowpriority_app": true,
   "lowpriority_app_cpu": "0.5",
   "lowpriority_app_mem": "1Gi",
-  "prometheus_app_mem": "21Gi",
+  "prometheus_app_mem": "18Gi",
   "prometheus_app_cpu": "0.5",
   "thanos_querier_mem": "2Gi",
   "thanos_store_mem": "5Gi",

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -54,6 +54,7 @@
     }
   },
   "ingress_nginx_version": "4.11.5",
+  "ingress_nginx_memory": "600Mi",
   "enable_lowpriority_app": true,
   "lowpriority_app_cpu": "0.5",
   "lowpriority_app_mem": "1Gi",

--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -104,7 +104,7 @@ resource "helm_release" "ingress-nginx" {
   }
   set {
     name  = "controller.resources.limits.memory"
-    value = "512Mi"
+    value = var.ingress_nginx_memory
     type  = "string"
   }
 

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -57,6 +57,12 @@ variable "ingress_nginx_version" {
   default     = "4.11.0"
 }
 
+variable "ingress_nginx_memory" {
+  description = "memory limit for nginx pods"
+  type        = string
+  default     = "512Mi"
+}
+
 variable "enable_lowpriority_app" {
   type    = bool
   default = false


### PR DESCRIPTION
## Context
Update memory limits for prometheus and nginx

## Changes proposed in this pull request
Decrease prometheus memory limit in test and prod clusters as tuning has lowered the memory usage
Increase nginx memory limit as usage has increased in the test cluster and we are seeing more frequent memory alerts

## Guidance to review
make test|production terraform-kubernetes-plan
update to 600Mi for nginx tested manually against platform-test

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
