### PR TITLE
feat(2488): bump controller version in dev and platform-test

### DIFF
--- a/cluster/terraform_kubernetes/config/development.tfvars.json
+++ b/cluster/terraform_kubernetes/config/development.tfvars.json
@@ -12,7 +12,7 @@
   "cluster_dns_resource_group_name": "s189d01-tscdomains-rg",
   "cluster_dns_zone": "development.teacherservices.cloud",
   "cluster_kv": "s189d01-tsc2-dv-kv",
-  "ingress_nginx_version": "4.11.5",
+  "ingress_nginx_version": "4.12.6",
   "thanos_retention_raw": "3d",
   "thanos_retention_5m": "10d",
   "thanos_retention_1h": "12d",

--- a/cluster/terraform_kubernetes/config/platform-test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/platform-test.tfvars.json
@@ -30,7 +30,7 @@
       ]
     }
   },
-  "ingress_nginx_version": "4.11.5",
+  "ingress_nginx_version": "4.12.6",
   "thanos_retention_raw": "3d",
   "thanos_retention_5m": "10d",
   "thanos_retention_1h": "12d",


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
- maintain versions nearer to current
https://trello.com/c/0DmNvcxN/2488-upgrade-ingress-nginx

## Changes proposed in this pull request
- bump controller version from 4.11.5. to 4.12.6

## Guidance to review
development:
<img width="1321" height="483" alt="Screenshot from 2025-09-08 11-20-55" src="https://github.com/user-attachments/assets/52269d30-1e30-4644-a442-d115c60d12da" />

test:
<img width="1291" height="474" alt="Screenshot from 2025-09-08 11-20-18" src="https://github.com/user-attachments/assets/1a096265-7273-4605-8b2a-9bd8d1cc9ff6" />

checked garafana dashboards still available for dev and platform-test
https://grafana.cluster3.development.teacherservices.cloud/dashboards
https://grafana.platform-test.teacherservices.cloud/dashboards

## Before merging
N/A

## After merging
N/A

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
