### PR TITLE
feat(2445): AKS upgrade & ingress-controller upgrade in test environment

### DIFF
--- a/cluster/terraform_aks_cluster/config/test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/test.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.31.5",
+  "kubernetes_version": "1.32.6",
   "default_node_pool": {
     "node_count": 2,
-    "orchestrator_version": "1.31.5"
+    "orchestrator_version": "1.32.6"
   },
   "node_pools": {
     "apps1": {
@@ -13,7 +13,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.31.5"
+      "orchestrator_version": "1.32.6"
     }
   },
   "admin_group_id": "21b2f2a6-231e-45cb-b624-d5521b820941"

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -54,7 +54,7 @@
       ]
     }
   },
-  "ingress_nginx_version": "4.11.5",
+  "ingress_nginx_version": "4.12.6",
   "ingress_nginx_memory": "600Mi",
   "enable_lowpriority_app": true,
   "lowpriority_app_cpu": "0.5",

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -32,6 +32,7 @@
     "tv-development",
     "tv-staging"
   ],
+  "kube_state_metrics_version": "2.15.0",
   "cluster_kv": "s189t01-tsc-ts-kv",
   "ingress_cert_name": "test-teacherservices-cloud-2",
   "statuscake_alerts": {


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context

- keep kubernetes versions up to date
-  https://trello.com/c/suqcFfwt/2445-aks-upgrade-from-1315-to-1326

## Changes proposed in this pull request
- upgrade test AKS cluster from 1.31.5 to 1.32.6

## Guidance to review
tested an itt review app:-
https://github.com/DFE-Digital/itt-mentor-services/actions/runs/17559797012/job/49873274962

<img width="1113" height="119" alt="Screenshot from 2025-09-08 19-13-55" src="https://github.com/user-attachments/assets/ca6f2699-79fe-440b-8676-348e2b88e427" />


## Before merging
N/A

## After merging
- i need to prep the PR for the manually applied nginx upgrade

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
