### PR TITLE
Increase test snat outbound port monitor threshold

### DIFF
--- a/cluster/terraform_aks_cluster/azure_metric_alerts.tf
+++ b/cluster/terraform_aks_cluster/azure_metric_alerts.tf
@@ -69,7 +69,7 @@ resource "azurerm_monitor_metric_alert" "high_port_usage" {
     metric_name      = "UsedSnatPorts"
     aggregation      = "Average"
     operator         = "GreaterThan"
-    threshold        = 900
+    threshold        = var.outbound_ports_threshold
     dimension {
       name     = "BackendIPAddress"
       operator = "Include"

--- a/cluster/terraform_aks_cluster/config/test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/test.tfvars.json
@@ -17,5 +17,6 @@
     }
   },
   "outbound_ports_allocated": 1560,
+  "outbound_ports_threshold": 1400,
   "admin_group_id": "21b2f2a6-231e-45cb-b624-d5521b820941"
 }

--- a/cluster/terraform_aks_cluster/variables.tf
+++ b/cluster/terraform_aks_cluster/variables.tf
@@ -43,6 +43,12 @@ variable "outbound_ports_allocated" {
   description = "Outbound ports allocated"
 }
 
+variable "outbound_ports_threshold" {
+  type        = number
+  default     = 900
+  description = "Outbound ports threshold for monitor alert"
+}
+
 locals {
   backing_services_resource_group_name = "${var.resource_prefix}-tsc-${var.environment}-bs-rg"
   cluster_name = (


### PR DESCRIPTION
## Context
Outbound snat ports per mode have been increased in the test cluster,
however the monitoring threshold is still at the original level.
This is causing high threshold alerts when we are well below the maximum allowed (1560).

## Changes proposed in this pull request
Increase the threshold from 900 to 1400 for the test cluster

## Guidance to review
make test terraform-plan (metric alert change)
make platform-test terraform-plan (no change)

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
