### PR TITLE
Use pv for /data for thanos-compactor

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -53,6 +53,7 @@
   "thanos_querier_mem": "2Gi",
   "thanos_app_cpu": "0.5",
   "thanos_compactor_mem": "7Gi",
+  "thanos_compactor_disk": 256,
   "thanos_store_mem": "5Gi",
   "cluster_short": "pd",
   "alertmanager_slack_receiver_list": [

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -64,6 +64,7 @@
   "thanos_querier_mem": "2Gi",
   "thanos_store_mem": "5Gi",
   "thanos_compactor_mem": "6Gi",
+  "thanos_compactor_disk": 256,
   "thanos_app_cpu": "0.5",
   "cluster_short": "ts",
   "alertable_apps": {

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -160,6 +160,12 @@ variable "thanos_compactor_mem" {
   default     = "1Gi"
 }
 
+variable "thanos_compactor_disk" {
+  type        = number
+  description = "Thanos compactor disk size"
+  default     = "16"
+}
+
 variable "thanos_store_mem" {
   type        = string
   description = "Thanos store gateway memory limit"


### PR DESCRIPTION
## Context
Thanos compactor can require more diskspace than is available on the underlying node.
It will then constantly fail to complete compaction.

## Changes proposed in this pull request
Add an azure disk to the compactor.
Default 16G, but set to 256G for test and prod.
This will be reviewed after 1 month and sizes changed if required.

## Guidance to review
Currently running for dev cluster5
make env terraform-kubernetes-plan

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
