### PR TITLE
Set container insights collection interval to 10m

### DIFF
--- a/cluster/terraform_aks_cluster/config/production.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/production.tfvars.json
@@ -16,6 +16,5 @@
       "orchestrator_version": "1.32.6"
     }
   },
-  "admin_group_id": "5b0f84de-54a8-481a-8689-f3c226597259",
-  "ci_collection_interval": "1m"
+  "admin_group_id": "5b0f84de-54a8-481a-8689-f3c226597259"
 }

--- a/cluster/terraform_aks_cluster/variables.tf
+++ b/cluster/terraform_aks_cluster/variables.tf
@@ -10,7 +10,7 @@ variable "managed_identity_name" {
 }
 variable "ci_collection_interval" {
   type        = string
-  default     = "5m"
+  default     = "10m"
   description = "Container Insights data collection interval"
 }
 


### PR DESCRIPTION
## Context
We don't use the container insights metrics that much as we use prometheus instead.
Collection of metrics in log analytics isn't cheap, so lowering the collection interval in the first instance, then review in a few months time.
prod 1m -> 10m
non-prod 5m -> 10m


## Changes proposed in this pull request
Change ci_collection_interval terraform variable to 10m

## Guidance to review
make env terraform-plan

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
