### PR TITLE
Fix scale command syntax in pg upgrade doc

### DIFF
--- a/documentation/postgres-upgrade.md
+++ b/documentation/postgres-upgrade.md
@@ -65,7 +65,7 @@ While auto analyze will eventually run against heavily modified tables, it will 
 - enable using the maintenance page workflow
 
 ### Shutdown the application (web and worker)
-- kubectl -n namespace deployment/service-env[-worker] --scale replicas=0
+- kubectl -n namespace scale deployment/service-env[-worker] replicas 0
 
 or
 - make env show-service
@@ -98,7 +98,7 @@ or
 - using the list of table stats taken before the upgrade, analyze selected tables manually using ANALYZE table_name;
 
 ### Start the application
-- kubectl -n namespace deployment/service-env[-worker] --scale replicas=n
+- kubectl -n namespace scale deployment/service-env[-worker] replicas 1 (match number pre scale down)
 
 or
 - make env scale-app REPLICAS=n


### PR DESCRIPTION
## Context
Incorrect use of kubectl scale command in the Postgres upgrade instructions

## Changes proposed in this pull request
Fix the command syntax

## Guidance to review
Review the instructions

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
