### PR TITLE
feat(2284): add Teams channel notify step to maintenance workflow

### DIFF
--- a/templates/new_service/.github/workflows/maintenance.yml
+++ b/templates/new_service/.github/workflows/maintenance.yml
@@ -36,3 +36,25 @@ jobs:
         mode: ${{ inputs.mode }}
         docker-repository: #DOCKER_REPOSITORY#-maintenance
         github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Send notification to Teams
+      run: |
+        payload=$(jq -n \
+        --arg repo "${{ github.repository }}" \
+        --arg actor "${{ github.actor }}" \
+        --arg env "${{ inputs.environment }}" \
+        --arg mode "${{ inputs.mode }}" \
+        --arg status "${{ job.status }}" \
+        --arg url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+        '{
+          repository: $repo,
+          actor: $actor,
+          environment: $env,
+          mode: $mode,
+          status: $status,
+          run_url: $url
+        }')
+
+        curl -X POST -H 'Content-Type: application/json' \
+          -d "$payload" \
+          "${{ secrets.TEAMS_WEBHOOK_URL }}"


### PR DESCRIPTION
## Context
- to update team members when an app is in maintenance mode

https://trello.com/c/JMmo5mCM/2284-maint-page-notification-to-teams-channel

## Changes proposed in this pull request
- create a PowerAutomate workflow to achieve the aims of this story
- amend maintenance workflow to include a step which uses the webhook to update a Teams channel with the updated status of the maintenance workflow after each new run

## Guidance to review
tested with npq:-
https://github.com/DFE-Digital/npq-registration/pull/2978/files

<img width="1599" height="310" alt="Screenshot from 2025-10-20 12-26-30" src="https://github.com/user-attachments/assets/c795eae7-6315-481b-a6a1-a3a0b6b27938" />


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
