### PR TITLE
Add gcp wif for sip namespaces

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -19,6 +19,7 @@
     "bat-production",
     "cpd-production",
     "git-production",
+    "sip-production",
     "srtl-production",
     "tra-production",
     "tv-production"

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -33,6 +33,8 @@
     "data-test",
     "git-development",
     "git-test",
+    "sip-development",
+    "sip-test",
     "srtl-development",
     "srtl-test",
     "tra-development",


### PR DESCRIPTION
## Context
Add gcp wif for the sip namespaces so we can enable dfe analytics for sap-public and sap-sector

## Changes proposed in this pull request
Add namespaces to gcp_wif_namespaces

make test|production terraform-kubernetes-plan

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
