### PR TITLE
Disable airbyte container logs to log analytics

### DIFF
--- a/airbyte/terraform/helm.tf
+++ b/airbyte/terraform/helm.tf
@@ -57,6 +57,11 @@ resource "helm_release" "airbyte" {
     type  = "auto"
   }
   set {
+    name  = "global.jobs.kube.annotations.fluentbit\\.io/exclude"
+    value = "true"
+    type  = "auto"
+  }
+  set {
     name  = "global.jobs.kube.nodeSelector.teacherservices\\.cloud/node_pool"
     value = "applications"
     type  = "string"
@@ -213,6 +218,11 @@ resource "helm_release" "airbyte" {
     type  = "string"
   }
   set {
+    name  = "webapp.podAnnotations.fluentbit\\.io/exclude"
+    value = "true"
+    type  = "string"
+  }
+  set {
     name  = "server.resources.limits.cpu"
     value = "600m"
     type  = "string"
@@ -245,6 +255,11 @@ resource "helm_release" "airbyte" {
   set {
     name  = "server.image.tag"
     value = "airbyte-server-1.5.1"
+    type  = "string"
+  }
+  set {
+    name  = "server.podAnnotations.fluentbit\\.io/exclude"
+    value = "true"
     type  = "string"
   }
   set {
@@ -283,6 +298,11 @@ resource "helm_release" "airbyte" {
     type  = "string"
   }
   set {
+    name  = "worker.podAnnotations.fluentbit\\.io/exclude"
+    value = "true"
+    type  = "string"
+  }
+  set {
     name  = "workload-launcher.resources.limits.cpu"
     value = "600m"
     type  = "string"
@@ -315,6 +335,11 @@ resource "helm_release" "airbyte" {
   set {
     name  = "workload-launcher.image.tag"
     value = "airbyte-workload-launcher-1.5.1"
+    type  = "string"
+  }
+  set {
+    name  = "workload-launcher.podAnnotations.fluentbit\\.io/exclude"
+    value = "true"
     type  = "string"
   }
   set {
@@ -353,6 +378,11 @@ resource "helm_release" "airbyte" {
     type  = "string"
   }
   set {
+    name  = "temporal.podAnnotations.fluentbit\\.io/exclude"
+    value = "true"
+    type  = "string"
+  }
+  set {
     name  = "cron.resources.limits.cpu"
     value = "600m"
     type  = "string"
@@ -380,6 +410,11 @@ resource "helm_release" "airbyte" {
   set {
     name  = "cron.image.repository"
     value = "ghcr.io/dfe-digital/teacher-services-cloud"
+    type  = "string"
+  }
+  set {
+    name  = "cron.podAnnotations.fluentbit\\.io/exclude"
+    value = "true"
     type  = "string"
   }
   set {
@@ -423,6 +458,11 @@ resource "helm_release" "airbyte" {
     type  = "string"
   }
   set {
+    name  = "connector-builder-server.podAnnotations.fluentbit\\.io/exclude"
+    value = "true"
+    type  = "string"
+  }
+  set {
     name  = "workload-api-server.resources.limits.cpu"
     value = "600m"
     type  = "string"
@@ -458,6 +498,11 @@ resource "helm_release" "airbyte" {
     type  = "string"
   }
   set {
+    name  = "workload-api-server.podAnnotations.fluentbit\\.io/exclude"
+    value = "true"
+    type  = "string"
+  }
+  set {
     name  = "airbyte-bootloader.nodeSelector.teacherservices\\.cloud/node_pool"
     value = "applications"
     type  = "string"
@@ -470,6 +515,11 @@ resource "helm_release" "airbyte" {
   set {
     name  = "airbyte-bootloader.image.tag"
     value = "airbyte-bootloader-1.5.1"
+    type  = "string"
+  }
+    set {
+    name  = "airbyte-bootloader.podAnnotations.fluentbit\\.io/exclude"
+    value = "true"
     type  = "string"
   }
 }

--- a/airbyte/terraform/token.tf
+++ b/airbyte/terraform/token.tf
@@ -52,6 +52,9 @@ for_each = toset(var.airbyte_namespaces)
           app              = "airbyte-token"
           "azure.workload.identity/use" = "true"
         }
+        annotations = {
+          "fluentbit.io/exclude" = "true"
+        }
       }
 
       spec {


### PR DESCRIPTION
## Context
Stop ending airbyte container and job logs to log analytics.
Sync logs go to a storage account, and we don't need to keep anything else longer than what's within aks.

## Changes proposed in this pull request
Add annotation to disable containerlogs

## Guidance to review
make env airbyte-plan

Applied to dev cluster 6 and you can see no airbyte logs are being sent to log analytics

<img width="893" height="417" alt="image" src="https://github.com/user-attachments/assets/b8cb75d8-d109-4a0f-86e5-2013b0656d29" />


## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
