### PR TITLE
Pin 3rd party github actions

### DIFF
--- a/.github/actions/validate-terraform/action.yml
+++ b/.github/actions/validate-terraform/action.yml
@@ -52,7 +52,7 @@ runs:
     shell: bash
     working-directory: ${{ inputs.terraform_root_folder }}
 
-  - uses: reviewdog/action-tflint@v1
+  - uses: reviewdog/action-tflint@54a5e5aed57dcfbb4662ec548de876df33d6288d # Pinned at v1.25.0
     with:
       github_token: ${{ inputs.github_token }}
       tflint_rulesets: azurerm


### PR DESCRIPTION
### Trello card

https://trello.com/c/8RwMeaL4/2682-pin-third-party-github-actions-mobilise

### Changes proposed in this pull request

- pin all 3rd party github actions at specific versions (for security)

### Guidance to review

see successful workflows run by this PR
