### PR TITLE
Increase prod apps1 nodepool max from 50 to 55

### DIFF
--- a/cluster/terraform_aks_cluster/config/production.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/production.tfvars.json
@@ -11,7 +11,7 @@
   "node_pools": {
     "apps1": {
       "min_count": 3,
-      "max_count": 50,
+      "max_count": 55,
       "vm_size": "Standard_E4ads_v5",
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
@@ -22,7 +22,7 @@
       "node_soak_duration_in_minutes": 1
     }
   },
-  "outbound_ports_allocated": 2160,
+  "outbound_ports_allocated": 2064,
   "outbound_ports_threshold": 1900,
   "admin_group_id": "5b0f84de-54a8-481a-8689-f3c226597259",
   "second_egress_ip": true


### PR DESCRIPTION
## Context
Looks like we are very close to the nodepool limit on prod

## Changes proposed in this pull request
Increase max from 50 to 55

Outbound ports decrease to x i.e. 128000 / 62 (55 + 3 + 3 + 1) = 2064

## Guidance to review
make production terraform-plan

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
