### PR TITLE
Upgrades the development AKS clusters to 1.34.6 and kube-state-metrics to 2.18.0

### DIFF
--- a/cluster/terraform_aks_cluster/.terraform.lock.hcl
+++ b/cluster/terraform_aks_cluster/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "4.61.0"
   constraints = "4.61.0"
   hashes = [
+    "h1:QWR72Af01CxqpKllMh92/uh00HQ3hNA526N6yyLdAUY=",
     "h1:RovkyY2wdFihSlz0qY5BQ0sgo1LJpKF8fu/7xre624Q=",
     "zh:314ce5459fd4a93aada8e99a2e2528d7df60f7145da0843d182a1d48f0c98a72",
     "zh:428bf3b41b6310dcd5f410a4be24dbd8b4d003aa82c0ac31718a7d9004fdc30e",

--- a/cluster/terraform_aks_cluster/config/development.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/development.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.33.7",
+  "kubernetes_version": "1.34.6",
   "default_node_pool": {
     "node_count": 1,
-    "orchestrator_version": "1.33.7",
+    "orchestrator_version": "1.34.6",
     "max_surge": 1,
     "drain_timeout_in_minutes": 15,
     "node_soak_duration_in_minutes": 1
@@ -15,7 +15,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.33.7",
+      "orchestrator_version": "1.34.6",
       "max_surge": 1,
       "drain_timeout_in_minutes": 15,
       "node_soak_duration_in_minutes": 1

--- a/cluster/terraform_kubernetes/config/development.tfvars.json
+++ b/cluster/terraform_kubernetes/config/development.tfvars.json
@@ -12,13 +12,13 @@
   "cluster_dns_resource_group_name": "s189d01-tscdomains-rg",
   "cluster_dns_zone": "development.teacherservices.cloud",
   "cluster_kv": "s189d01-tsc2-dv-kv",
-  "ingress_nginx_version": "4.13.4",
+  "ingress_nginx_version": "4.15.1",
   "thanos_retention_raw": "3d",
   "thanos_retention_5m": "10d",
   "thanos_retention_1h": "12d",
   "cluster_short": "dv",
   "block_metrics_endpoint" : false,
-  "kube_state_metrics_version": "2.17.0",
+  "kube_state_metrics_version": "2.18.0",
   "ga_wif_managed_id": {
     "bat": {
       "itt-mentor-services": ["dv_review"]


### PR DESCRIPTION
…s to 2.18.0

<!-- Delete sections if not required -->

## Context
This upgrades the development clusters tfavrs to use Kubernetes version 1.34.6, also changes kube-state-metrics to version 2.18.0 to bring in line with Kubernetes version.

## Changes proposed in this pull request
Upgrade Kubernetes version for development, no dependancy on other PRs 

## Guidance to review
Pull branch and deploy a development cluster and confirm kubernetes version 1.34.6 across the control plane and node pools.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
