### PR TITLE
Upgrades platfom-test cluster to 1.34.6

### DIFF
--- a/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.33.7",
+  "kubernetes_version": "1.34.6",
   "default_node_pool": {
     "node_count": 2,
-    "orchestrator_version": "1.33.7",
+    "orchestrator_version": "1.34.6",
     "max_surge": 1,
     "drain_timeout_in_minutes": 15,
     "node_soak_duration_in_minutes": 1
@@ -15,7 +15,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.33.7",
+      "orchestrator_version": "1.34.6",
       "max_surge": 1,
       "drain_timeout_in_minutes": 15,
       "node_soak_duration_in_minutes": 1

--- a/cluster/terraform_kubernetes/config/platform-test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/platform-test.tfvars.json
@@ -8,7 +8,7 @@
     "staging",
     "test"
   ],
-  "kube_state_metrics_version": "2.17.0",
+  "kube_state_metrics_version": "2.18.0",
   "gcp_wif_namespaces": ["development"],
   "cluster_kv": "s189t01-tsc-pt-kv",
   "statuscake_alerts": {
@@ -30,7 +30,7 @@
       ]
     }
   },
-  "ingress_nginx_version": "4.13.4",
+  "ingress_nginx_version": "4.15.1",
   "thanos_retention_raw": "3d",
   "thanos_retention_5m": "10d",
   "thanos_retention_1h": "12d",


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
Upgrades platform-test AKS cluster to Kubernetes version 1.34.6 along with kube-state-metrics to v2.18.0 and nginx to v4.15.1 of the helm chart.

## Guidance to review
Can check that platform-test cluster is at v1.34.6 in Azure console and via kubectl commands.
