### PR TITLE
Upgrades test cluster to v1.34.6

### DIFF
--- a/cluster/terraform_aks_cluster/config/test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/test.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.33.7",
+  "kubernetes_version": "1.34.6",
   "default_node_pool": {
     "node_count": 2,
-    "orchestrator_version": "1.33.7",
+    "orchestrator_version": "1.34.6",
     "max_surge": 1,
     "drain_timeout_in_minutes": 15,
     "node_soak_duration_in_minutes": 1
@@ -16,7 +16,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.33.7",
+      "orchestrator_version": "1.34.6",
       "max_surge": 3,
       "drain_timeout_in_minutes": 15,
       "node_soak_duration_in_minutes": 1

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -42,7 +42,7 @@
     "tv-development",
     "tv-staging"
   ],
-  "kube_state_metrics_version": "2.17.0",
+  "kube_state_metrics_version": "2.18.0",
   "cluster_kv": "s189t01-tsc-ts-kv",
   "ingress_cert_name": "test-teacherservices-cloud-2",
   "statuscake_alerts": {
@@ -64,7 +64,7 @@
       ]
     }
   },
-  "ingress_nginx_version": "4.13.4",
+  "ingress_nginx_version": "4.15.1",
   "ingress_nginx_memory": "600Mi",
   "enable_lowpriority_app": true,
   "lowpriority_app_cpu": "0.5",


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
Upgrades the test AKS cluster to Kubernetes v1.34.6, kube-state-metrics to v2.18.0 and nginx to v4.15.1 of the Helm chart.

## Changes proposed in this pull request
Kubernetes to v1.34.6
kube-state-metrics to v2.18.0
nginx helm chart to 4.15.1
