### PR TITLE
Disable filebeat send to analytics container logs

### DIFF
--- a/cluster/terraform_kubernetes/filebeat.tf
+++ b/cluster/terraform_kubernetes/filebeat.tf
@@ -96,6 +96,9 @@ resource "kubernetes_daemonset" "filebeat" {
         labels = {
           app = "filebeat"
         }
+        annotations = {
+          "fluentbit.io/exclude" = "true"
+        }
       }
 
       spec {
@@ -290,6 +293,9 @@ resource "kubernetes_daemonset" "filebeat_clone" {
       metadata {
         labels = {
           app = "filebeat"
+        }
+        annotations = {
+          "fluentbit.io/exclude" = "true"
         }
       }
 


### PR DESCRIPTION
## Context
We don't need to send filebeat logs to log analytics

## Changes proposed in this pull request
Add annotation to deployments to stop the sending of logs

## Guidance to review
deployed to dev cluster at 12.01 and filebeat logs no longer going to log analytics

<img width="648" height="502" alt="image" src="https://github.com/user-attachments/assets/0e3dccf3-c8bd-4695-b123-e80462e17f45" />

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
