### PR TITLE
Add cypd prometheus monitoring for prod

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -91,7 +91,8 @@
     "TEAMS_WEBHOOK_TV",
     "TEAMS_WEBHOOK_ITTMS",
     "TEAMS_WEBHOOK_PTT",
-    "TEAMS_WEBHOOK_AFQTS"
+    "TEAMS_WEBHOOK_AFQTS",
+    "TEAMS_WEBHOOK_CYPD"
   ],
   "alertable_apps": {
     "bat-production/apply-production": {
@@ -263,6 +264,9 @@
     },
     "sip-production/sap-public-production": {
       "receiver": "TEAMS_WEBHOOK_SIP"
+    },
+    "schoolstandards-production/check-performance-data-production": {
+      "receiver": "TEAMS_WEBHOOK_CYPD"
     }
   },
   "ga_wif_managed_id": {


### PR DESCRIPTION
## Context
Add prometheus monitoring for new service CYPD production

## Changes proposed in this pull request
- add webhook secret, 
- add service to production tfvars alertable_apps and alertmanager_teams_receiver_list

## Guidance to review
make production terraform-kubernetes-plan

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
