### PR TITLE
Upgrades production AKS cluster 10 1.34.6

### DIFF
--- a/cluster/terraform_aks_cluster/config/production.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/production.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.33.7",
+  "kubernetes_version": "1.34.6",
   "default_node_pool": {
     "node_count": 3,
-    "orchestrator_version": "1.33.7",
+    "orchestrator_version": "1.34.6",
     "max_surge": 1,
     "drain_timeout_in_minutes": 15,
     "node_soak_duration_in_minutes": 1
@@ -16,7 +16,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.33.7",
+      "orchestrator_version": "1.34.6",
       "max_surge": 3,
       "drain_timeout_in_minutes": 15,
       "node_soak_duration_in_minutes": 1

--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -24,7 +24,7 @@
     "tra-production",
     "tv-production"
   ],
-  "kube_state_metrics_version": "2.17.0",
+  "kube_state_metrics_version": "2.18.0",
   "cluster_kv": "s189p01-tsc-pd-kv",
   "statuscake_alerts": {
     "tscluster-production": {
@@ -66,7 +66,7 @@
     "platform-test.teacherservices.cloud",
     "development.teacherservices.cloud"
   ],
-  "ingress_nginx_version": "4.13.4",
+  "ingress_nginx_version": "4.15.1",
   "enable_lowpriority_app": true,
   "prometheus_app_mem": "14Gi",
   "prometheus_app_cpu": "0.5",


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
Upgrades the production AKS cluster to Kubernetes v1.34.6, kube-state-metrics to v2.18.0 and nginx to v4.15.1 of the Helm chart.

## Changes proposed in this pull request
Kubernetes to v1.34.6
kube-state-metrics to v2.18.0
nginx helm chart to 4.15.1
