### PR TITLE
Add traefik config

### DIFF
--- a/cluster/terraform_kubernetes/config/dashboards/grafana-services-traefik.json
+++ b/cluster/terraform_kubernetes/config/dashboards/grafana-services-traefik.json
@@ -1,0 +1,339 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Traefik Requests Dashboard - showing HTTP request counts by status (2xx, 4xx, 5xx) per service",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": 14,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P5DCFC7561CCDE821"
+      },
+      "description": "HTTP request rate by individual status code over time. Stacked bars show distribution of 200, 301, 302, 404, 500, 503 responses.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "200"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "301"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "302"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "404"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "500"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "503"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "maxPerRow": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.5",
+      "repeat": "service",
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P5DCFC7561CCDE821"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(traefik_service_requests_total{kubernetes_namespace=~\"$namespace\", service=~\"$service\", code=~\"2..\"}[$__interval])) or vector(0)",
+          "interval": "5m",
+          "intervalFactor": 1,
+          "legendFormat": "2xx",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P5DCFC7561CCDE821"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(traefik_service_requests_total{kubernetes_namespace=~\"$namespace\", service=~\"$service\", code=~\"3..\"}[$__interval])) or vector(0)",
+          "interval": "5m",
+          "intervalFactor": 1,
+          "legendFormat": "3xx",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P5DCFC7561CCDE821"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(traefik_service_requests_total{kubernetes_namespace=~\"$namespace\", service=~\"$service\", code=~\"4..\"}[$__interval])) or vector(0)",
+          "interval": "5m",
+          "intervalFactor": 1,
+          "legendFormat": "4xx",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P5DCFC7561CCDE821"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(traefik_service_requests_total{kubernetes_namespace=~\"$namespace\", service=~\"$service\", code=~\"5..\"}[$__interval])) or vector(0)",
+          "interval": "5m",
+          "intervalFactor": 1,
+          "legendFormat": "5xx",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "$service",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 41,
+  "tags": [
+    "nginx",
+    "ingress",
+    "requests",
+    "services"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P5DCFC7561CCDE821"
+        },
+        "definition": "label_values(traefik_service_requests_total,kubernetes_namespace)",
+        "includeAll": true,
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(traefik_service_requests_total,kubernetes_namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "^(?!.*-review-)(?!.*-pr-).*$",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P5DCFC7561CCDE821"
+        },
+        "definition": "label_values(traefik_service_requests_total,service)",
+        "includeAll": true,
+        "multi": true,
+        "name": "service",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(traefik_service_requests_total,service)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "^(?!.*-review-)(?!.*-pr-).*$",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Traefik Requests Dashboard",
+  "uid": "traefik-requests-dashboard",
+  "version": 5
+}

--- a/cluster/terraform_kubernetes/config/dashboards/traefik-kubernetes.json
+++ b/cluster/terraform_kubernetes/config/dashboards/traefik-kubernetes.json
@@ -1,0 +1,1545 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Official dashboard for Traefik on Kubernetes",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 14,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 9,
+      "panels": [],
+      "title": "General",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P5DCFC7561CCDE821"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 5,
+        "x": 0,
+        "y": 1
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P5DCFC7561CCDE821"
+          },
+          "editorMode": "code",
+          "expr": "count(traefik_config_reloads_total)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Traefik Instances",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P5DCFC7561CCDE821"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 5,
+        "y": 1
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P5DCFC7561CCDE821"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(traefik_entrypoint_requests_total{entrypoint=~\"$entrypoint\"}[$interval])) by (entrypoint)",
+          "legendFormat": "{{entrypoint}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests per Entrypoint",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P5DCFC7561CCDE821"
+      },
+      "description": "https://medium.com/@tristan_96324/prometheus-apdex-alerting-d17a065e39d0",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P5DCFC7561CCDE821"
+          },
+          "editorMode": "code",
+          "expr": "(sum(rate(traefik_entrypoint_request_duration_seconds_bucket{le=\"0.3\",code=\"200\",entrypoint=~\"$entrypoint\"}[$interval])) by (method) + \n sum(rate(traefik_entrypoint_request_duration_seconds_bucket{le=\"1.2\",code=\"200\",entrypoint=~\"$entrypoint\"}[$interval])) by (method)) / 2 / \n sum(rate(traefik_entrypoint_request_duration_seconds_count{code=\"200\",entrypoint=~\"$entrypoint\"}[$interval])) by (method)\n",
+          "legendFormat": "{{method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Apdex score",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P5DCFC7561CCDE821"
+      },
+      "description": "Mean Distribution",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 5,
+        "x": 0,
+        "y": 3
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "percent"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "asc"
+        }
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P5DCFC7561CCDE821"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(traefik_service_requests_total{service=~\"$service.*\",protocol=\"http\"}[$interval])) by (method, code)",
+          "legendFormat": "{{method}}[{{code}}]",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Http Code ",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P5DCFC7561CCDE821"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P5DCFC7561CCDE821"
+          },
+          "editorMode": "code",
+          "expr": "topk(15,\n    label_replace(\n        traefik_service_request_duration_seconds_sum{service=~\"$service.*\",protocol=\"http\"} / \n          traefik_service_request_duration_seconds_count{service=~\"$service.*\",protocol=\"http\"},\n        \"service\", \"$1\", \"service\", \"([^@]+)@.*\")\n)\n\n",
+          "legendFormat": "{{method}}[{{code}}] on {{service}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top slow services",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P5DCFC7561CCDE821"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P5DCFC7561CCDE821"
+          },
+          "editorMode": "code",
+          "expr": "topk(15,\n    label_replace(\n        sum by (service,code) \n          (rate(traefik_service_requests_total{service=~\"$service.*\",protocol=\"http\"}[$interval])) > 0,\n        \"service\", \"$1\", \"service\", \"([^@]+)@.*\")\n)",
+          "legendFormat": "[{{code}}] on {{service}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Most requested services",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 11,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P5DCFC7561CCDE821"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P5DCFC7561CCDE821"
+              },
+              "editorMode": "code",
+              "expr": "label_replace(\n  1 - (sum by (service)\n    (rate(traefik_service_request_duration_seconds_bucket{le=\"1.2\",service=~\"$service.*\"}[$interval])) / sum by (service) \n    (rate(traefik_service_request_duration_seconds_count{service=~\"$service.*\"}[$interval]))\n  ) > 0,\n  \"service\", \"$1\", \"service\", \"([^@]+)@.*\"\n)",
+              "legendFormat": "{{service}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Services failing SLO of 1200ms",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P5DCFC7561CCDE821"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 18
+          },
+          "id": 4,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "sortBy": "Max",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "P5DCFC7561CCDE821"
+              },
+              "editorMode": "code",
+              "expr": "label_replace(\n  1 - (sum by (service)\n    (rate(traefik_service_request_duration_seconds_bucket{le=\"0.3\",service=~\"$service.*\"}[$interval])) / sum by (service) \n    (rate(traefik_service_request_duration_seconds_count{service=~\"$service.*\"}[$interval]))\n  ) > 0,\n  \"service\", \"$1\", \"service\", \"([^@]+)@.*\"\n)",
+              "legendFormat": "{{service}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Services failing SLO of 300ms",
+          "type": "timeseries"
+        }
+      ],
+      "title": "SLO",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 16,
+      "panels": [],
+      "title": "HTTP Details",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P5DCFC7561CCDE821"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 8,
+        "x": 0,
+        "y": 19
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P5DCFC7561CCDE821"
+          },
+          "editorMode": "code",
+          "expr": "topk(15,\n    label_replace(\n        sum by (service,method,code) \n          (rate(traefik_service_requests_total{service=~\"$service.*\",code=~\"2..\",protocol=\"http\"}[$interval])) > 0,\n        \"service\", \"$1\", \"service\", \"([^@]+)@.*\")\n)",
+          "legendFormat": "{{method}}[{{code}}] on {{service}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "2xx over $interval",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P5DCFC7561CCDE821"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": true,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 8,
+        "x": 8,
+        "y": 19
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P5DCFC7561CCDE821"
+          },
+          "editorMode": "code",
+          "expr": "topk(15,\n    label_replace(\n        sum by (service,method,code) \n          (rate(traefik_service_requests_total{service=~\"$service.*\",code=~\"5..\",protocol=\"http\"}[$interval])) > 0,\n        \"service\", \"$1\", \"service\", \"([^@]+)@.*\")\n)",
+          "legendFormat": "{{method}}[{{code}}] on {{service}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "5xx over $interval",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P5DCFC7561CCDE821"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": true,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 8,
+        "x": 16,
+        "y": 19
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P5DCFC7561CCDE821"
+          },
+          "editorMode": "code",
+          "expr": "topk(15,\n    label_replace(\n        sum by (service,method,code) \n          (rate(traefik_service_requests_total{service=~\"$service.*\",code!~\"2..|5..\",protocol=\"http\"}[$interval])) > 0,\n        \"service\", \"$1\", \"service\", \"([^@]+)@.*\")\n)",
+          "legendFormat": "{{method}}[{{code}}] on {{service}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Other codes over $interval",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P5DCFC7561CCDE821"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": true,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P5DCFC7561CCDE821"
+          },
+          "editorMode": "code",
+          "expr": "topk(15,\n    label_replace(\n        sum by (service,method) \n          (rate(traefik_service_requests_bytes_total{service=~\"$service.*\",protocol=\"http\"}[$interval])) > 0,\n        \"service\", \"$1\", \"service\", \"([^@]+)@.*\")\n)",
+          "legendFormat": "{{method}} on {{service}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P5DCFC7561CCDE821"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisGridShow": true,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "binBps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P5DCFC7561CCDE821"
+          },
+          "editorMode": "code",
+          "expr": "topk(15,\n    label_replace(\n        sum by (service,method) \n          (rate(traefik_service_responses_bytes_total{service=~\"$service.*\",protocol=\"http\"}[$interval])) > 0,\n        \"service\", \"$1\", \"service\", \"([^@]+)@.*\")\n)",
+          "legendFormat": "{{method}} on {{service}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Responses Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P5DCFC7561CCDE821"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 39
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P5DCFC7561CCDE821"
+          },
+          "editorMode": "code",
+          "expr": "sum(traefik_open_connections{entrypoint=~\"$entrypoint\"}) by (entrypoint)\n",
+          "legendFormat": "{{entrypoint}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Connections per Entrypoint",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "",
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "Thanos",
+          "value": "P5DCFC7561CCDE821"
+        },
+        "includeAll": false,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P5DCFC7561CCDE821"
+        },
+        "definition": "label_values(traefik_open_connections, entrypoint)",
+        "includeAll": true,
+        "name": "entrypoint",
+        "options": [],
+        "query": {
+          "query": "label_values(traefik_open_connections, entrypoint)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "auto": true,
+        "auto_count": 30,
+        "auto_min": "1m",
+        "current": {
+          "text": "$__auto",
+          "value": "$__auto"
+        },
+        "name": "interval",
+        "options": [
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          },
+          {
+            "selected": false,
+            "text": "2h",
+            "value": "2h"
+          },
+          {
+            "selected": false,
+            "text": "4h",
+            "value": "4h"
+          },
+          {
+            "selected": false,
+            "text": "8h",
+            "value": "8h"
+          }
+        ],
+        "query": "1m,5m,10m,30m,1h,2h,4h,8h",
+        "refresh": 2,
+        "type": "interval"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P5DCFC7561CCDE821"
+        },
+        "definition": "label_values(traefik_service_requests_total, service)",
+        "includeAll": true,
+        "name": "service",
+        "options": [],
+        "query": {
+          "query": "label_values(traefik_service_requests_total, service)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/([^@]+)@.*/",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Traefik Official Kubernetes Dashboard",
+  "uid": "n5bu_kv4k",
+  "version": 1
+}

--- a/cluster/terraform_kubernetes/config/development.tfvars.json
+++ b/cluster/terraform_kubernetes/config/development.tfvars.json
@@ -10,9 +10,6 @@
     "traefik"
   ],
   "traefik-watch": [
-    "development",
-    "monitoring",
-    "traefik"
   ],
   "gcp_wif_namespaces": ["development"],
   "cluster_dns_resource_group_name": "s189d01-tscdomains-rg",
@@ -33,5 +30,9 @@
   "enable_traefik": true,
   "add_traefik_ingress_ip": true,
   "add_traefik_to_dns": true,
-  "ingress_nginx_replicaCount": 10
+  "add_nginx_to_dns": false,
+  "ingress_nginx_replicaCount": 0,
+  "enable_nginx": false,
+  "add_nginx_ingress_ip": false,
+  "create_nginx_ingressclass": true
 }

--- a/cluster/terraform_kubernetes/config/development.tfvars.json
+++ b/cluster/terraform_kubernetes/config/development.tfvars.json
@@ -6,7 +6,13 @@
     "monitoring",
     "qa",
     "staging",
-    "test"
+    "test",
+    "traefik"
+  ],
+  "traefik-watch": [
+    "development",
+    "monitoring",
+    "traefik"
   ],
   "gcp_wif_namespaces": ["development"],
   "cluster_dns_resource_group_name": "s189d01-tscdomains-rg",
@@ -23,5 +29,9 @@
     "bat": {
       "itt-mentor-services": ["dv_review"]
     }
-  }
+  },
+  "enable_traefik": true,
+  "add_traefik_ingress_ip": true,
+  "add_traefik_to_dns": true,
+  "ingress_nginx_replicaCount": 10
 }

--- a/cluster/terraform_kubernetes/config/traefik/development.values.yaml
+++ b/cluster/terraform_kubernetes/config/traefik/development.values.yaml
@@ -1,0 +1,181 @@
+#https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml
+
+providers:
+  kubernetesIngressNGINX:
+    enabled: true
+    # -- Ingress Class Controller value this controller satisfies
+    controllerClass: "k8s.io/ingress-nginx"
+    # -- Name of the ingress class this controller satisfies
+    ingressClass: "nginx"
+    # -- Define if Ingress Controller should watch for Ingress Class by Name together with Controller Class
+    ingressClassByName: false
+    # -- Define if Ingress Controller should also watch for Ingresses without an IngressClass or the annotation specified
+    watchIngressWithoutClass: false
+    # -- Single namespace the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespaceSelector.
+    # watchNamespace: "development"
+    # -- Select namespaces the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespace.
+    # comment out when ready for all namespaces in traefik
+    #watchNamespaceSelector: "traefik-watch=true"
+    publishService:
+      # -- Service fronting the Ingress controller. Takes the form 'namespace/name'
+      enabled: true
+    proxyBodySize: 52428800
+    proxyBufferSize: 24576
+    upstreamKeepaliveTimeout: 120
+
+  # kubernetesIngress:
+  #   enabled: false # this is default true and maybe it's required?
+  kubernetesCRD:
+    enabled: true # this is default true and maybe it's required?
+    allowCrossNamespace: true
+
+global:
+  checkNewVersion: false      # set to false to disable
+  sendAnonymousUsage: false   # set to true to enable
+
+ports:
+  web:
+    ## -- Enable this entrypoint as a default entrypoint. When a service doesn't explicitly set an entrypoint it will only use this entrypoint.
+    expose:
+      default: false
+  websecure:
+    ## -- Enable this entrypoint as a default entrypoint. When a service doesn't explicitly set an entrypoint it will only use this entrypoint.
+    # asDefault: true
+    port: 8443 # this is default
+    exposedPort: 443 # this is default
+    http:
+      middlewares:
+        - "traefik-blockmetrics@kubernetescrd"
+        # - "traefik-test-ratelimit@kubernetescrd"
+
+extraObjects:
+  - apiVersion: traefik.io/v1alpha1
+    kind: Middleware
+    metadata:
+      name: "blockmetrics"
+    spec:
+      replacePathRegex:
+        regex: "/metrics$"
+        replacement: "/nometrics"
+  # - apiVersion: traefik.io/v1alpha1
+  #   kind: Middleware
+  #   metadata:
+  #     name: "test-ratelimit"
+  #   spec:
+  #     rateLimit:
+  #       average: 500
+  #       period: 300s
+  #       burst: 1000
+
+deployment:
+  replicas: 5
+  # -- Additional pod annotations (e.g. for mesh injection or prometheus scraping)
+  # It supports templating. One can set it with values like traefik/name: '{{ template "traefik.name" . }}'
+  podAnnotations:
+    # prometheus.io/port: "15014" #why this port?
+    # prometheus.io/scrape: "true"
+    # prometheus.io/path: "/metrics"
+    logit.io/send: "true"
+    fluentbit.io/exclude: "true"
+
+  # readinessPath: "/ping"
+  # livenessPath: "/ping"
+  # healthchecksPort: Default: ports.traefik.port
+
+nodeSelector:
+  teacherservices.cloud/node_pool: "applications"
+
+topologySpreadConstraints:
+- maxSkew: 1
+  topologyKey: kubernetes.io/hostname
+  whenUnsatisfiable: ScheduleAnyway
+  labelSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+
+logs:
+  general:
+    format: json
+    level: INFO
+  access:
+    enabled: true
+    format: json # default: "common"
+    fields:
+      general:
+        names:
+          ClientAddr: drop
+          ClientUsername: drop
+          ClientPort: drop
+          GzipRatio: drop
+          RequestAddr: drop
+          OriginContentSize: drop
+          RequestCount: drop
+          RequestHost: drop
+          RequestPort: drop
+          StartLocal: drop
+          ServiceURL: drop
+          ServiceAddr: drop
+
+service:
+  spec:
+    externalTrafficPolicy: Local # is this in values.yaml?
+
+# -- [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for `traefik` container.
+resources:
+  limits:
+    cpu: "1"
+    memory: "1Gi"
+  requests:
+    cpu: "100m"
+    memory: "250Mi"
+
+#Name of the Kubernetes Secret served for connections without a SNI, or without a matching domain. If no default certificate is provided, Traefik will use the generated one
+# -- TLS Store are created as [TLSStore CRDs](https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/crd/tls/tlsstore/).
+# This is useful if you want to set a default certificate. See EXAMPLE.md for details.
+
+tlsStore:
+  default:
+    certificates:
+    - secretName: cert-secret-traefik
+    defaultCertificate:
+      secretName: cert-secret-traefik
+
+volumes:
+- mountPath: /certs
+  name: cert-secret-traefik
+  type: secret
+
+rbac:  # @schema additionalProperties: false
+  # -- Whether Role Based Access Control objects like roles and rolebindings should be created
+  enabled: true # default true
+
+# -- The service account the pods will use to interact with the Kubernetes API
+#serviceAccount:  # @schema additionalProperties: false
+  # If set, an existing service account is used
+  # If not set, a service account is created automatically using the fullname template
+  #name: ""
+
+additionalArguments: [ "--log.level=INFO" ]
+#  - "--providers.kubernetesingress.ingressclass=traefik-internal"
+#  - "--log.level=DEBUG" normally INFO
+
+ingressRoute:
+  dashboard:
+    # -- Create an IngressRoute for the dashboard
+    enabled: true
+  healthcheck:
+    # -- Create an IngressRoute for the healthcheck probe
+    enabled: false
+
+podDisruptionBudget:  # @schema additionalProperties: false
+  enabled: true # default false
+  #maxUnavailable:  0 # default unset
+  minAvailable:    "50%" # default unset
+
+# default settings below
+updateStrategy:  # @schema additionalProperties: false
+  # -- Customize updateStrategy of Deployment or DaemonSet
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: "50%"  # @schema type:[integer, string, null]
+    maxSurge: 1        # @schema type:[integer, string, null]

--- a/cluster/terraform_kubernetes/dns.tf
+++ b/cluster/terraform_kubernetes/dns.tf
@@ -16,5 +16,5 @@ resource "azurerm_dns_a_record" "cluster_a_record" {
   zone_name           = var.cluster_dns_zone
   resource_group_name = var.cluster_dns_resource_group_name
   ttl                 = 300
-  records             = toset([data.kubernetes_service.default.status[0].load_balancer[0].ingress[0].ip])
+  records             = toset([data.kubernetes_service.default.status[0].load_balancer[0].ingress[0].ip, local.traefik_ip])
 }

--- a/cluster/terraform_kubernetes/dns.tf
+++ b/cluster/terraform_kubernetes/dns.tf
@@ -16,5 +16,5 @@ resource "azurerm_dns_a_record" "cluster_a_record" {
   zone_name           = var.cluster_dns_zone
   resource_group_name = var.cluster_dns_resource_group_name
   ttl                 = 300
-  records             = toset([data.kubernetes_service.default.status[0].load_balancer[0].ingress[0].ip, local.traefik_ip])
+  records             = local.dns_ip
 }

--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -1,8 +1,12 @@
 resource "helm_release" "ingress-nginx" {
+  count = var.enable_nginx ? 1 : 0
+
   name       = "ingress-nginx"
   repository = "https://kubernetes.github.io/ingress-nginx"
   chart      = "ingress-nginx"
   version    = var.ingress_nginx_version
+
+  reuse_values = var.enable_traefik ? true : false
 
   # The first part of the name with simple dots is the keys path in the values.yml file e.g. controller.service.annotations
   # The last part is the final key e.g. service\\.beta\\.kubernetes\\.io/azure-load-balancer-health-probe-request-path
@@ -18,13 +22,13 @@ resource "helm_release" "ingress-nginx" {
   # The cluster managed identity must have Network Contributor role on the resource group
   set {
     name  = "controller.service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-resource-group"
-    value = azurerm_public_ip.ingress-public-ip.resource_group_name
+    value = azurerm_public_ip.ingress-public-ip[0].resource_group_name
     type  = "string"
   }
   # Ingress IP
   set {
     name  = "controller.service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-ipv4"
-    value = azurerm_public_ip.ingress-public-ip.ip_address
+    value = azurerm_public_ip.ingress-public-ip[0].ip_address
     type  = "string"
   }
   # Route requests from the load balancer to the ingress pods on the same node instead of adding one more hop to the node with most pods.
@@ -142,12 +146,24 @@ resource "helm_release" "ingress-nginx" {
     type  = "string"
   }
 
+  # Set resource-policy annotation to keep
+  dynamic "set" {
+    for_each = var.enable_traefik ? [1] : []
+
+    content {
+      name  = "controller.ingressClassResource.annotations.helm\\.sh/resource-policy"
+      value = "keep"
+      type  = "string"
+    }
+  }
+
   # Set ingress class name so it can be retrieved as an attribute to force dependencies
   set {
     name  = "controller.ingressClassResource.name"
     value = "nginx"
     type  = "string"
   }
+
   # Block access to /metrics endpoint
   dynamic "set" {
     for_each = var.block_metrics_endpoint ? [1] : []
@@ -216,15 +232,15 @@ resource "helm_release" "ingress-nginx-clone" {
   count    = var.clone_cluster ? 1 : 0
   provider = helm.clone
 
-  name       = helm_release.ingress-nginx.name
-  repository = helm_release.ingress-nginx.repository
-  chart      = helm_release.ingress-nginx.chart
-  version    = helm_release.ingress-nginx.version
+  name       = helm_release.ingress-nginx[0].name
+  repository = helm_release.ingress-nginx[0].repository
+  chart      = helm_release.ingress-nginx[0].chart
+  version    = helm_release.ingress-nginx[0].version
 
   dynamic "set" {
     # Exclude the load balancer IP to force clone to use dynamic Public IP for load balancer ingress
     for_each = [
-      for s in helm_release.ingress-nginx.set : s
+      for s in helm_release.ingress-nginx[0].set : s
       if s.name != "controller.service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-ipv4"
       && s.name != "controller.service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-resource-group"
     ]
@@ -252,6 +268,8 @@ resource "helm_release" "ingress-nginx-clone" {
 }
 
 resource "azurerm_public_ip" "ingress-public-ip" {
+  count = var.add_nginx_ingress_ip ? 1 : 0
+
   name                = "${var.resource_prefix}-tsc-aks-nodes-${var.environment}-ingress-pip"
   location            = data.azurerm_resource_group.resource_group.location
   resource_group_name = data.azurerm_resource_group.resource_group.name

--- a/cluster/terraform_kubernetes/ingress_controller.tf
+++ b/cluster/terraform_kubernetes/ingress_controller.tf
@@ -74,7 +74,7 @@ resource "helm_release" "ingress-nginx" {
   }
   set {
     name  = "controller.replicaCount"
-    value = 20
+    value = var.ingress_nginx_replicaCount
     type  = "auto"
   }
   set {

--- a/cluster/terraform_kubernetes/namespaces.tf
+++ b/cluster/terraform_kubernetes/namespaces.tf
@@ -1,9 +1,10 @@
 resource "kubernetes_namespace" "default_list" {
+
   for_each = toset(var.namespaces)
   metadata {
     name = each.key
     labels = {
-      traefik-watch = contains(var.traefik-watch, each.key) ? true : false
+      traefik-watch = contains(var.traefik-watch, each.key) ? true : null
     }
   }
 }

--- a/cluster/terraform_kubernetes/namespaces.tf
+++ b/cluster/terraform_kubernetes/namespaces.tf
@@ -2,6 +2,9 @@ resource "kubernetes_namespace" "default_list" {
   for_each = toset(var.namespaces)
   metadata {
     name = each.key
+    labels = {
+      traefik-watch = contains(var.traefik-watch, each.key) ? true : false
+    }
   }
 }
 

--- a/cluster/terraform_kubernetes/tls.tf
+++ b/cluster/terraform_kubernetes/tls.tf
@@ -43,6 +43,22 @@ resource "kubernetes_secret_v1" "kube_cert_secret" {
   type = "kubernetes.io/tls"
 }
 
+resource "kubernetes_secret_v1" "kube_cert_secret_traefik" {
+  count = var.enable_traefik ? 1 : 0
+
+  metadata {
+    name      = "cert-secret-traefik"
+    namespace = "traefik"
+  }
+
+  data = {
+    "tls.crt" = local.reversed_full_cert
+    "tls.key" = data.azurerm_key_vault_certificate_data.cert.key
+  }
+
+  type = "kubernetes.io/tls"
+}
+
 resource "kubernetes_secret_v1" "kube_cert_secret_clone" {
   count    = var.clone_cluster ? 1 : 0
   provider = kubernetes.clone

--- a/cluster/terraform_kubernetes/traefik_ingress.tf
+++ b/cluster/terraform_kubernetes/traefik_ingress.tf
@@ -1,0 +1,49 @@
+resource "helm_release" "traefik-ingress" {
+  count = var.enable_traefik ? 1 : 0
+
+  name       = "traefik"
+  repository = "https://traefik.github.io/charts"
+  chart      = "traefik"
+  version    = var.traefik_ingress_version
+  namespace  = "traefik"
+  values = [
+    file("${path.module}/config/traefik/${var.config}.values.yaml")
+  ]
+
+  set {
+    name  = "service.spec.externalTrafficPolicy"
+    value = "Local"
+  }
+  set {
+    name  = "service.annotations.service\\.beta\\.kubernetes\\.io/azure-pip-name"
+    value = azurerm_public_ip.ingress-public-ip-traefik[0].name
+    type  = "string"
+  }
+  # Resource group of the ingress public IP
+  # The cluster managed identity must have Network Contributor role on the resource group
+  set {
+    name  = "service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-resource-group"
+    value = data.azurerm_resource_group.resource_group.name
+    type  = "string"
+  }
+  set {
+    name  = "service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-health-probe-request-path"
+    value = "/healthz"
+    type  = "string"
+  }
+
+}
+
+resource "azurerm_public_ip" "ingress-public-ip-traefik" {
+  count = var.add_traefik_ingress_ip ? 1 : 0
+
+  name                = "${var.resource_prefix}-tsc-aks-nodes-${var.environment}-traefik-ingress-pip"
+  location            = data.azurerm_resource_group.resource_group.location
+  resource_group_name = data.azurerm_resource_group.resource_group.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+
+  timeouts {}
+
+  lifecycle { ignore_changes = [tags] }
+}

--- a/cluster/terraform_kubernetes/traefik_ingress.tf
+++ b/cluster/terraform_kubernetes/traefik_ingress.tf
@@ -47,3 +47,19 @@ resource "azurerm_public_ip" "ingress-public-ip-traefik" {
 
   lifecycle { ignore_changes = [tags] }
 }
+
+resource "kubernetes_ingress_class" "nginx" {
+  count = var.create_nginx_ingressclass ? 1 : 0
+
+  metadata {
+    name = "nginx"
+    labels = {
+      "app.kubernetes.io/name" = "ingress-nginx"
+    }
+  }
+
+  spec {
+    controller = "k8s.io/ingress-nginx"
+  }
+
+}

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -75,6 +75,30 @@ variable "ingress_nginx_replicaCount" {
   default     = 20
 }
 
+variable "enable_nginx" {
+  description = "Enable or disable install of the nginx ingress"
+  type        = bool
+  default     = true
+}
+
+variable "create_nginx_ingressclass" {
+  description = "Enable or disable install of the nginx ingressclass"
+  type        = bool
+  default     = false
+}
+
+variable "add_nginx_ingress_ip" {
+  type        = bool
+  default     = true
+  description = "Allocate an ingress public IP for nginx"
+}
+
+variable "add_nginx_to_dns" {
+  type        = bool
+  default     = true
+  description = "Add the nginx_ip to the cluster dns"
+}
+
 variable "traefik_ingress_version" {
   description = "Version of the traefik ingress helm chart to use"
   type        = string
@@ -425,7 +449,7 @@ locals {
 
   # Get value from helm_release attribute to force dependency
   # and make sure the ingress controller is created before the ingresses
-  ingress_class_name = jsondecode(helm_release.ingress-nginx.metadata[0].values)["controller"]["ingressClassResource"]["name"]
+  ingress_class_name = var.enable_nginx ? jsondecode(helm_release.ingress-nginx[0].metadata[0].values)["controller"]["ingressClassResource"]["name"] : "nginx"
 
   default_welcome_app_hostname = "www.${module.cluster_data.ingress_domain}"
   welcome_app_hostnames        = concat(var.welcome_app_hostnames, [local.default_welcome_app_hostname])
@@ -434,4 +458,8 @@ locals {
   grafana_dashboards_map = { for d in local.grafana_dasboards : d => file("${path.module}/config/dashboards/${d}") }
 
   traefik_ip = var.add_traefik_to_dns ? azurerm_public_ip.ingress-public-ip-traefik[0].ip_address : ""
+  nginx_ip   = var.add_nginx_to_dns ? azurerm_public_ip.ingress-public-ip[0].ip_address : ""
+  #nginx_ip   = var.enable_nginx ? data.kubernetes_service.default.status[0].load_balancer[0].ingress[0].ip : ""
+
+  dns_ip = var.add_traefik_to_dns ? (var.add_nginx_to_dns ? toset([local.nginx_ip, local.traefik_ip]) : toset([local.traefik_ip])) : toset([local.nginx_ip])
 }

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -24,6 +24,12 @@ variable "ingress_cert_name" {
   default = null
 }
 variable "namespaces" { type = list(string) }
+
+variable "traefik-watch" {
+  type    = list(string)
+  default = []
+}
+
 variable "gcp_wif_namespaces" {
   description = "List of namespaces with Azure GCP Wokload Identity Federation enabled"
   type        = list(string)
@@ -61,6 +67,36 @@ variable "ingress_nginx_memory" {
   description = "memory limit for nginx pods"
   type        = string
   default     = "512Mi"
+}
+
+variable "ingress_nginx_replicaCount" {
+  description = "number of nginx pods"
+  type        = number
+  default     = 20
+}
+
+variable "traefik_ingress_version" {
+  description = "Version of the traefik ingress helm chart to use"
+  type        = string
+  default     = "v40.2.0"
+}
+
+variable "enable_traefik" {
+  description = "Enable or disable install of the traefik ingress"
+  type        = bool
+  default     = false
+}
+
+variable "add_traefik_ingress_ip" {
+  type        = bool
+  default     = false
+  description = "Allocate an ingress public IP for traefik"
+}
+
+variable "add_traefik_to_dns" {
+  type        = bool
+  default     = false
+  description = "Add the traefik_ip to the cluster dns"
 }
 
 variable "enable_lowpriority_app" {
@@ -396,4 +432,6 @@ locals {
 
   grafana_dasboards      = fileset("${path.module}/config/dashboards", "*.json")
   grafana_dashboards_map = { for d in local.grafana_dasboards : d => file("${path.module}/config/dashboards/${d}") }
+
+  traefik_ip = var.add_traefik_to_dns ? azurerm_public_ip.ingress-public-ip-traefik[0].ip_address : ""
 }

--- a/documentation/traefik-migration.md
+++ b/documentation/traefik-migration.md
@@ -18,32 +18,42 @@ Traefik can monitor and takeover
 - all namespaces
     - set neither watchNamespace or watchNamespaceSelector
 
-There are 3 terraform variables.
+There are 3 terraform variables for traefik.
 All default to false, and will be updated per environment as they are migrated
 
 - add_traefik_ingress_ip, which adds a PIP for traefik
 - enable_traefik, which deploys the traefik ingress and associated resources
 - add_traefik_to_dns, which adds the ip to the cluster dns
 
+There are also 4 new nginx variables.
+- add_nginx_ingress_ip (default true), which adds a PIP for nginx
+- enable_nginx (default true), which deploys the nginx ingress and associated resources
+- create_nginx_ingressclass (default false), will create a ngnx ingressclass for new clusters that only use traefik
+- add_nginx_to_dns (default true) which adds the ip to the cluster dns
+
 ## Overall Procedure
 
 Starting with dev, then platform-test, then test and finally production
 There will be several weeks of running on test before we migrate production.
 
-1. set add_traefik_ingress_ip to true
+Start by copying the cluster/terraform_kubernetes/config/traefik/develpment.values.yaml to a new clusterenv.values.yaml and amend as required.
+
+1. set add_traefik_ingress_ip to true and redeploy
 - for test and production, advise service teams in case there are allow lists that need to be updated
 
-2. set enable_traefik to true
+2. set enable_traefik to true and redeploy
 - use a single namespace initially, set watchNamespace: "traefik"
 
-3. set add_traefik_to_dns to true
+3. set add_traefik_to_dns to true and redploy
 
 4. enable for extra namespaces
 - advise service teams this change will take place
 - set watchNamespaceSelector: "traefik-watch=true" and add traefik and monitoring namespaces to traefik-watch
     - remove watchNamespace: "traefik" at the same time
+    - redeploy with the above changes
 - confirm access to services in these namespaces. There is caching of DNS locally, so you may need to use a private browser window to pick up the traefik ingress.
 - add extra namespaces and test e.g. bat-qa.
+    - when adding extra namespaces traefik will need to be redeployed or scaled down/up to pick up the changes
     - this step might be skipped for production. tbc
 
 5. check traefik ingress status
@@ -57,14 +67,16 @@ There will be several weeks of running on test before we migrate production.
 
 6. enable for all namespaces
 - advise service teams this change will take place
-- remove watchNamespaceSelector and watchNamespace
+- remove watchNamespaceSelector and watchNamespace and redeploy
 - scale nginx-ingress to 0 replicas manually
+    - kubectl -n default scale deployment/ingress-nginx-controller --replicas=0
 - edit the ingress-nginx-admission webhook and set failurePolicy to Ignore
     - kubectl edit validatingwebhookconfigurations/ingress-nginx-admission
     - otherwise deployments will fail if they try to create an ingress
-- if ok, set "ingress_nginx_replicaCount" to 0
+- if ok, set "ingress_nginx_replicaCount" to 0 and redeploy
+    - check the admission webhook hasn't changed back to Fail after redeploy
 
-For production, it might be better to do the below in a single window of 1 or 2 hours (tbc)
+For production, it might be better to do the below in a single window of 1 or 2 hours
 - migrate to traefik out of hours (early morning)
 - temporarily adding selected namespaces and monitoring
 - then adding all namespaces and complete scale down of nginx
@@ -75,15 +87,44 @@ For production, it might be better to do the below in a single window of 1 or 2 
 
 At any time, revert back to the nginx-ingress by
 - scale up nginx-ingress
+    - kubectl -n default scale deployment/ingress-nginx-controller --replicas=10|20
 - edit the ingress-nginx-admission webhook and set failurePolicy to Fail
     - kubectl edit validatingwebhookconfigurations/ingress-nginx-admission
 - scale down traefik to 0 replicas.
+    - kubectl -n traefik scale deployment/traefik --replicas=0
 
 ## Post migration
 
-At a later stage the nginx ingress and public IP should be removed entirely, but the helm chart removes the nginx IngressClass. Traefik needs this IngressClass to detect and serve Ingress resources that use ingressClassName: nginx.
-So when uninstalling NGINX, make sure you keep or create a kubernetes ingressclass with name nginx and controller k8s.io/ingress-nginx.
+At a later stage the nginx ingress and public IP should be removed entirely.
+
+The current helm chart configuration removes the nginx IngressClass on removal.
+Traefik needs this IngressClass to detect and serve Ingress resources that use ingressClassName: nginx.
+So when uninstalling NGINX, we need to make sure we keep the kubernetes ingressclass with name nginx and controller k8s.io/ingress-nginx. Dropping the ingressclass for just a short period would result in traefik dropping all the ingress.
+Consider adding watchIngressWithoutClass: true once nginx has been removed.
 see https://doc.traefik.io/traefik/migrate/nginx-to-traefik/#preserve-the-ingressclass
+The nginx helm config will be updated to keep the ingressclass when traefik is enabled.
+
 Removal should also start with development, then platform-test, test, production.
 
-Also remove the public IP. As mentioned previously consider if switching traefik to the nginx IP and removing the more recent addition is of any benefit.
+This can be done by settting enable_nginx to false in the terraform config for the target cluster.
+It will remove the nginx resources and remove the ip from the cluster DNS.
+
+Note that we set the nginx helm chart to not delete the nginx ingressclass when it's removed.
+But that means a new cluster (e.g. development) without nginx will not have the ingressclass.
+So a terraform kubernetes_ingress resource will be created if create_nginx_ingressclass is set to true, and this should be the normal setting for development clusters.
+If one of the other clusters is recreated after nginx is removed it will also need that parameter set to true.
+
+As mentioned previously consider if switching traefik to the nginx IP and removing the more recent addition is of any benefit.
+
+Steps
+
+1. Remove nginx IP from DNS
+    -set add_nginx_to_dns to false
+    -It will still be connected to lb while the cache propogates
+    -wait a day or two before continuing to the next step
+
+2. Set enable_nginx to false
+    - redeploy
+
+3. Set add_nginx_ingress_ip to false.
+    - redeploy

--- a/documentation/traefik-migration.md
+++ b/documentation/traefik-migration.md
@@ -1,0 +1,89 @@
+# Traefik ingress migration
+
+This document covers the migration plan from nginx ingress to traefik ingress
+
+## Overview
+
+See https://doc.traefik.io/traefik/migrate/nginx-to-traefik/
+
+The Traefik ingress can be installed alongside the current nginx ingress.
+Using the kubernetesIngressNGINX provider, it can monitor kubernetes ingress and create the appropraite traefik resources and then takeover the ingress from nginx. No change is required for the existing ingress configuration.
+
+Traefik can monitor and takeover
+- a single namespace
+    - set watchNamespace: "bat-qa"
+- a group of namespaces
+    - set watchNamespaceSelector: "traefik-watch=true"
+    - then add namespaces to the traefik-watch terraform variable, which will add the label to each one
+- all namespaces
+    - set neither watchNamespace or watchNamespaceSelector
+
+There are 3 terraform variables.
+All default to false, and will be updated per environment as they are migrated
+
+- add_traefik_ingress_ip, which adds a PIP for traefik
+- enable_traefik, which deploys the traefik ingress and associated resources
+- add_traefik_to_dns, which adds the ip to the cluster dns
+
+## Overall Procedure
+
+Starting with dev, then platform-test, then test and finally production
+There will be several weeks of running on test before we migrate production.
+
+1. set add_traefik_ingress_ip to true
+- for test and production, advise service teams in case there are allow lists that need to be updated
+
+2. set enable_traefik to true
+- use a single namespace initially, set watchNamespace: "traefik"
+
+3. set add_traefik_to_dns to true
+
+4. enable for extra namespaces
+- advise service teams this change will take place
+- set watchNamespaceSelector: "traefik-watch=true" and add traefik and monitoring namespaces to traefik-watch
+    - remove watchNamespace: "traefik" at the same time
+- confirm access to services in these namespaces. There is caching of DNS locally, so you may need to use a private browser window to pick up the traefik ingress.
+- add extra namespaces and test e.g. bat-qa.
+    - this step might be skipped for production. tbc
+
+5. check traefik ingress status
+- check traffic dashboard
+    - kubectl -n traefik port-forward deploy/traefik 8080:8080
+    - http://localhost:8080/dashboard/
+- check grafana dashboards for traefik
+- check traefik access logs in logit, updating logstash as per the development logit stack
+- check performance of traefik pods, looking at cpu/memory and restarts
+- ask service teams to check services
+
+6. enable for all namespaces
+- advise service teams this change will take place
+- remove watchNamespaceSelector and watchNamespace
+- scale nginx-ingress to 0 replicas manually
+- edit the ingress-nginx-admission webhook and set failurePolicy to Ignore
+    - kubectl edit validatingwebhookconfigurations/ingress-nginx-admission
+    - otherwise deployments will fail if they try to create an ingress
+- if ok, set "ingress_nginx_replicaCount" to 0
+
+For production, it might be better to do the below in a single window of 1 or 2 hours (tbc)
+- migrate to traefik out of hours (early morning)
+- temporarily adding selected namespaces and monitoring
+- then adding all namespaces and complete scale down of nginx
+- monitor closely as users start using the services
+- it is possible to switch the existing public ip assigned to nginx to traefik if required
+
+## Rollback
+
+At any time, revert back to the nginx-ingress by
+- scale up nginx-ingress
+- edit the ingress-nginx-admission webhook and set failurePolicy to Fail
+    - kubectl edit validatingwebhookconfigurations/ingress-nginx-admission
+- scale down traefik to 0 replicas.
+
+## Post migration
+
+At a later stage the nginx ingress and public IP should be removed entirely, but the helm chart removes the nginx IngressClass. Traefik needs this IngressClass to detect and serve Ingress resources that use ingressClassName: nginx.
+So when uninstalling NGINX, make sure you keep or create a kubernetes ingressclass with name nginx and controller k8s.io/ingress-nginx.
+see https://doc.traefik.io/traefik/migrate/nginx-to-traefik/#preserve-the-ingressclass
+Removal should also start with development, then platform-test, test, production.
+
+Also remove the public IP. As mentioned previously consider if switching traefik to the nginx IP and removing the more recent addition is of any benefit.


### PR DESCRIPTION
## Context
Add Traefik ingress resources and configuration, and set development clusters to install with the traefik ingress only by default.

## Changes proposed in this pull request
- add terraform for traefik ingress
- add variables to enable the switch from nginx to traefik per cluster
- add dashboards
- add traefik migration documentation

## Guidance to review
See dev cluster5 which is running with traefik only.
Install a dev cluster, and check all works as expected.
make development terraform-apply
For all other clusters, it should only add the new dashboards.
i.e. make platform-test|test|production terraform-plan

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
