### PR TITLE
Add fix-airbyte-lsn workflow

### DIFF
--- a/.github/workflows/fix-airbyte-lsn.yml
+++ b/.github/workflows/fix-airbyte-lsn.yml
@@ -1,0 +1,60 @@
+name: Fix Airbyte LSN
+
+on:
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: Kubernetes namespace
+        required: true
+        default: bat-qa
+        type: choice
+        options:
+          - bat-qa
+          - bat-staging
+          - tra-development
+          - tra-test
+          - tra-production
+      cluster:
+        description: Cluster name
+        required: true
+        default: test
+        type: choice
+        options:
+          - test
+          - production
+      connection-id:
+        description: Airbyte connection UUID to reset state for
+        required: true
+      dry-run:
+        description: Dry run — inspect state only, do not delete
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+permissions:
+  id-token: write
+
+jobs:
+  fix-lsn:
+    name: Fix Airbyte LSN state
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.cluster }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+
+    - name: Fix Airbyte LSN state
+      uses: DFE-Digital/github-actions/fix-airbyte-lsn@master
+      with:
+        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        namespace: ${{ inputs.namespace }}
+        cluster: ${{ inputs.cluster }}
+        connection-id: ${{ inputs.connection-id }}
+        dry-run: ${{ inputs.dry-run }}


### PR DESCRIPTION
### Context

When Airbyte fails to sync due to an LSN mismatch error, the saved state in the Airbyte internal database needs to be cleared so Airbyte can start fresh. This workflow makes that fix available as a manual trigger rather than requiring someone to connect to the database and run SQL manually.

### Changes proposed in this pull request

Added a new workflow .github/workflows/fix-airbyte-lsn-error.yml that can be triggered manually. You provide the environment, namespace and connection UUID and it handles connecting to the Airbyte internal database and clearing the saved state for that connection. It calls a composite action from the github-actions repo so the actual logic lives in one place.

This PR needs the fix-airbyte-lsn-error action in DFE-Digital/github-actions to be merged first before this will work.

### Guidance to review

The connection UUID can be found in the Airbyte GUI under Connections → select the connection → Settings. Test against a non-production namespace first before using in production.

### Before merging

Make sure the composite action PR in DFE-Digital/github-actions is merged first.

### After merging

Nothing extra needed  the workflow is triggered manually when an LSN error occurs.

### Checklist

- [ ]  I have performed a self-review of my code, including formatting and typos
- [ ]  I have cleaned the commit history
- [ ]  I have added the Devops label
- [ ]  I have attached the pull request to the trello card