### PR TITLE
Add queue privatelink DNS zone

### DIFF
--- a/cluster/terraform_aks_cluster/variables.tf
+++ b/cluster/terraform_aks_cluster/variables.tf
@@ -98,7 +98,8 @@ locals {
   ]
   privatelink_dns_zone_names = [
     "privatelink.redis.cache.windows.net",
-    "privatelink.blob.core.windows.net"
+    "privatelink.blob.core.windows.net",
+    "privatelink.queue.core.windows.net"
   ]
   uk_south_availability_zones = ["1", "2", "3"]
   monitor_action_group_name   = "${var.resource_prefix}-tsc"


### PR DESCRIPTION
## Context
CYPD want to use Storage Account queues. The storage account module needs a `privatelink.queue.core.windows.net` DNS zone at the cluster level to support this  without it, the private endpoint the module creates won't resolve correctly.

This needs to land and be applied everywhere before the terraform-modules PR goes in.

## Changes proposed in this pull request
One line added to `privatelink_dns_zone_names` in `cluster/terraform_aks_cluster/variables.tf`:

```hcl
"privatelink.queue.core.windows.net"
```



## Guidance to review
Just the one line. After applying, check the backing services resource group in each environment has the new DNS zone and VNet link created.

## After merging
- Apply to all environments 
- Confirm DNS zone and VNet link exist in Azure
- go-ahead for the terraform-modules PR

## Checklist
- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [[cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [x] I have attached the pull request to the trello card