### PR TITLE
Update domains.sh formatting

### DIFF
--- a/templates/new_service.sh
+++ b/templates/new_service.sh
@@ -107,13 +107,11 @@ unset OPTIONS_BLOCK
 
 #DOMAINS GLOBAL CONFIG
 cat <<EOF > new_service/global_config/domains.sh
-{
-      AZURE_SUBSCRIPTION=s189-teacher-services-cloud-production
-      AZURE_RESOURCE_PREFIX=s189p01
-      CONFIG_SHORT=dom
-      DISABLE_KEYVAULTS=true
-      TERRAFORM_MODULES_TAG=stable
-}
+AZURE_SUBSCRIPTION=s189-teacher-services-cloud-production
+AZURE_RESOURCE_PREFIX=s189p01
+CONFIG_SHORT=dom
+DISABLE_KEYVAULTS=true
+TERRAFORM_MODULES_TAG=stable
 EOF
 
 echo Rendering template...


### PR DESCRIPTION
## Context
This change is a bug fix, to correct an issue where the make commands for domains would not be able to read the variables correctly.

## Changes proposed in this pull request
Updated new_service.sh file, to generate the domains.sh file in the correct formatting so it can be used in make commands.

## Guidance to review
Confirm that the formatting for domains.sh is not enclosed in parentheses and does not include indentation, so it matches the format of other environment files such as production.sh. This has been tested locally and the works as expected with the new formatting.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
