### PR TITLE
fix missing comma in privatelink_dns_zone_names variable

### DIFF
--- a/cluster/terraform_aks_cluster/variables.tf
+++ b/cluster/terraform_aks_cluster/variables.tf
@@ -99,7 +99,7 @@ locals {
   privatelink_dns_zone_names = [
     "privatelink.redis.cache.windows.net",
     "privatelink.blob.core.windows.net",
-    "redis.azure.net"
+    "redis.azure.net",
     "privatelink.queue.core.windows.net"
   ]
   uk_south_availability_zones = ["1", "2", "3"]


### PR DESCRIPTION
## Context
Fix missing comma in privatelink_dns_zone_names variable, currently failing on validate workflow

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
