### PR TITLE
Enable traefik ingress in platform-test

### DIFF
--- a/cluster/terraform_kubernetes/config/platform-test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/platform-test.tfvars.json
@@ -6,7 +6,8 @@
     "monitoring",
     "qa",
     "staging",
-    "test"
+    "test",
+    "traefik"
   ],
   "kube_state_metrics_version": "2.18.0",
   "gcp_wif_namespaces": ["development"],
@@ -14,7 +15,7 @@
   "statuscake_alerts": {
     "tscluster-platform-test": {
       "website_name": "Teacher-Services-AKS-Cluster-PLATFORM-TEST",
-      "website_url": "https://status.platform-test.teacherservices.cloud/healthz",
+      "website_url": "https://www.platform-test.teacherservices.cloud/",
       "check_rate": 60,
       "contact_group": [
         282453
@@ -23,7 +24,7 @@
   },
   "statuscake_ssl_alerts": {
     "tscluster-platform-test-ssl": {
-      "website_url": "https://status.platform-test.teacherservices.cloud/healthz",
+      "website_url": "https://www.platform-test.teacherservices.cloud/",
       "check_rate": 3600,
       "contact_group": [
         282453
@@ -45,5 +46,11 @@
     "development": {
       "teaching-record-system": ["pentest"]
     }
-  }
+  },
+  "enable_traefik": true,
+  "add_traefik_ingress_ip": true,
+  "ingress_nginx_replicaCount": 10,
+  "enable_nginx": true,
+  "add_nginx_ingress_ip": true,
+  "create_nginx_ingressclass": false
 }

--- a/cluster/terraform_kubernetes/config/traefik/platform-test.values.yaml
+++ b/cluster/terraform_kubernetes/config/traefik/platform-test.values.yaml
@@ -1,0 +1,181 @@
+#https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml
+
+providers:
+  kubernetesIngressNGINX:
+    enabled: true
+    # -- Ingress Class Controller value this controller satisfies
+    controllerClass: "k8s.io/ingress-nginx"
+    # -- Name of the ingress class this controller satisfies
+    ingressClass: "nginx"
+    # -- Define if Ingress Controller should watch for Ingress Class by Name together with Controller Class
+    ingressClassByName: false
+    # -- Define if Ingress Controller should also watch for Ingresses without an IngressClass or the annotation specified
+    watchIngressWithoutClass: false
+    # -- Single namespace the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespaceSelector.
+    # watchNamespace: "development"
+    # -- Select namespaces the controller watches for updates to Kubernetes objects. Mutually exclusive with watchNamespace.
+    # comment out when ready for all namespaces in traefik
+    #watchNamespaceSelector: "traefik-watch=true"
+    publishService:
+      # -- Service fronting the Ingress controller. Takes the form 'namespace/name'
+      enabled: false
+    proxyBodySize: 52428800
+    proxyBufferSize: 24576
+    upstreamKeepaliveTimeout: 120
+
+  # kubernetesIngress:
+  #   enabled: false # this is default true and maybe it's required?
+  kubernetesCRD:
+    enabled: true # this is default true and maybe it's required?
+    allowCrossNamespace: true
+
+global:
+  checkNewVersion: false      # set to false to disable
+  sendAnonymousUsage: false   # set to true to enable
+
+ports:
+  web:
+    ## -- Enable this entrypoint as a default entrypoint. When a service doesn't explicitly set an entrypoint it will only use this entrypoint.
+    expose:
+      default: false
+  websecure:
+    ## -- Enable this entrypoint as a default entrypoint. When a service doesn't explicitly set an entrypoint it will only use this entrypoint.
+    # asDefault: true
+    port: 8443 # this is default
+    exposedPort: 443 # this is default
+    http:
+      middlewares:
+        - "traefik-blockmetrics@kubernetescrd"
+        # - "traefik-test-ratelimit@kubernetescrd"
+
+extraObjects:
+  - apiVersion: traefik.io/v1alpha1
+    kind: Middleware
+    metadata:
+      name: "blockmetrics"
+    spec:
+      replacePathRegex:
+        regex: "/metrics$"
+        replacement: "/nometrics"
+  # - apiVersion: traefik.io/v1alpha1
+  #   kind: Middleware
+  #   metadata:
+  #     name: "test-ratelimit"
+  #   spec:
+  #     rateLimit:
+  #       average: 500
+  #       period: 300s
+  #       burst: 1000
+
+deployment:
+  replicas: 10
+  # -- Additional pod annotations (e.g. for mesh injection or prometheus scraping)
+  # It supports templating. One can set it with values like traefik/name: '{{ template "traefik.name" . }}'
+  podAnnotations:
+    # prometheus.io/port: "15014" #why this port?
+    # prometheus.io/scrape: "true"
+    # prometheus.io/path: "/metrics"
+    logit.io/send: "true"
+    fluentbit.io/exclude: "true"
+
+  # readinessPath: "/ping"
+  # livenessPath: "/ping"
+  # healthchecksPort: Default: ports.traefik.port
+
+nodeSelector:
+  teacherservices.cloud/node_pool: "applications"
+
+topologySpreadConstraints:
+- maxSkew: 1
+  topologyKey: kubernetes.io/hostname
+  whenUnsatisfiable: ScheduleAnyway
+  labelSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+
+logs:
+  general:
+    format: json
+    level: INFO
+  access:
+    enabled: true
+    format: json # default: "common"
+    fields:
+      general:
+        names:
+          ClientAddr: drop
+          ClientUsername: drop
+          ClientPort: drop
+          GzipRatio: drop
+          RequestAddr: drop
+          OriginContentSize: drop
+          RequestCount: drop
+          RequestHost: drop
+          RequestPort: drop
+          StartLocal: drop
+          ServiceURL: drop
+          ServiceAddr: drop
+
+service:
+  spec:
+    externalTrafficPolicy: Local # is this in values.yaml?
+
+# -- [Resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for `traefik` container.
+resources:
+  limits:
+    cpu: "1"
+    memory: "1Gi"
+  requests:
+    cpu: "100m"
+    memory: "250Mi"
+
+#Name of the Kubernetes Secret served for connections without a SNI, or without a matching domain. If no default certificate is provided, Traefik will use the generated one
+# -- TLS Store are created as [TLSStore CRDs](https://doc.traefik.io/traefik/reference/routing-configuration/kubernetes/crd/tls/tlsstore/).
+# This is useful if you want to set a default certificate. See EXAMPLE.md for details.
+
+tlsStore:
+  default:
+    certificates:
+    - secretName: cert-secret-traefik
+    defaultCertificate:
+      secretName: cert-secret-traefik
+
+volumes:
+- mountPath: /certs
+  name: cert-secret-traefik
+  type: secret
+
+rbac:  # @schema additionalProperties: false
+  # -- Whether Role Based Access Control objects like roles and rolebindings should be created
+  enabled: true # default true
+
+# -- The service account the pods will use to interact with the Kubernetes API
+#serviceAccount:  # @schema additionalProperties: false
+  # If set, an existing service account is used
+  # If not set, a service account is created automatically using the fullname template
+  #name: ""
+
+additionalArguments: [ "--log.level=INFO" ]
+#  - "--providers.kubernetesingress.ingressclass=traefik-internal"
+#  - "--log.level=DEBUG" normally INFO
+
+ingressRoute:
+  dashboard:
+    # -- Create an IngressRoute for the dashboard
+    enabled: true
+  healthcheck:
+    # -- Create an IngressRoute for the healthcheck probe
+    enabled: false
+
+podDisruptionBudget:  # @schema additionalProperties: false
+  enabled: true # default false
+  #maxUnavailable:  0 # default unset
+  minAvailable:    "50%" # default unset
+
+# default settings below
+updateStrategy:  # @schema additionalProperties: false
+  # -- Customize updateStrategy of Deployment or DaemonSet
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: "50%"  # @schema type:[integer, string, null]
+    maxSurge: 1        # @schema type:[integer, string, null]

--- a/documentation/traefik-migration.md
+++ b/documentation/traefik-migration.md
@@ -23,13 +23,13 @@ All default to false, and will be updated per environment as they are migrated
 
 - add_traefik_ingress_ip, which adds a PIP for traefik
 - enable_traefik, which deploys the traefik ingress and associated resources
-- add_traefik_to_dns, which adds the ip to the cluster dns
+- add_traefik_to_dns, which adds the ip to the cluster dns (for dev only)
 
 There are also 4 new nginx variables.
 - add_nginx_ingress_ip (default true), which adds a PIP for nginx
 - enable_nginx (default true), which deploys the nginx ingress and associated resources
 - create_nginx_ingressclass (default false), will create a ngnx ingressclass for new clusters that only use traefik
-- add_nginx_to_dns (default true) which adds the ip to the cluster dns
+- add_nginx_to_dns (default true) which adds the ip to the cluster dns (for dev only)
 
 ## Overall Procedure
 
@@ -44,7 +44,10 @@ Start by copying the cluster/terraform_kubernetes/config/traefik/develpment.valu
 2. set enable_traefik to true and redeploy
 - use a single namespace initially, set watchNamespace: "traefik"
 
-3. set add_traefik_to_dns to true and redploy
+3. Update DNS
+    - for development, set add_traefik_to_dns to true and redploy
+    - for other clusters, update the A record in custom_domains/terraform/infrastructure/production.tfvars.json
+    - this will need to be temporarily removed from cicd as the code doesn't work with two addresses
 
 4. enable for extra namespaces
 - advise service teams this change will take place
@@ -119,7 +122,8 @@ As mentioned previously consider if switching traefik to the nginx IP and removi
 Steps
 
 1. Remove nginx IP from DNS
-    -set add_nginx_to_dns to false
+    -set add_nginx_to_dns to false (for dev)
+    -for other clusters, remove the A record in custom_domains/terraform/infrastructure/production.tfvars.json
     -It will still be connected to lb while the cache propogates
     -wait a day or two before continuing to the next step
 


### PR DESCRIPTION
## Context
Enable traefik ingress for the traefik and monitoring namespaces in the platform-test cluster
Nginx ingress will still be active for all other namespaces.

## Changes proposed in this pull request
- add traefik values yaml for platform-test
- set required variables in platform-test.tfvars.json 

## Guidance to review
make platform-test terraform-kubernetes-plan

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
