### PR TITLE
Added missing value to global template config files

### DIFF
--- a/templates/new_service_config/global_config/qa.env
+++ b/templates/new_service_config/global_config/qa.env
@@ -1,3 +1,4 @@
+CONFIG=qa
 CLUSTER=test
 ENVIRONMENT=qa
 AZURE_SUBSCRIPTION=s189-teacher-services-cloud-test

--- a/templates/new_service_config/global_config/test.env
+++ b/templates/new_service_config/global_config/test.env
@@ -1,3 +1,4 @@
+CONFIG=test
 CLUSTER=test
 ENVIRONMENT=test
 AZURE_SUBSCRIPTION=s189-teacher-services-cloud-test


### PR DESCRIPTION
## Context
Some deployment steps in the service onboarding process to not work correctly due to a missing variable in the environment template files.

## Changes proposed in this pull request
The CONFIG variable is missing in the template files for the test and qa environments, meaning that some commands fail later in the onboarding process. This was noticed when validating the domain resources, as the variable is used to populate the file name, but would fail as shown in the attached screenshot.

## Guidance to review
This has already been tested and confirmed to resolve the issue. Review the code changes and confirm that it matches the contents of other environment files such as production, review and development.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
<img width="638" height="84" alt="image" src="https://github.com/user-attachments/assets/b176b491-75a3-4c5e-985b-076d8db4838b" />
