### PR TITLE
Added variables for gitint credentials

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -295,7 +295,8 @@
     "git": {
       "schools-experience": ["production"],
       "get-into-teaching-api": ["production"],
-      "get-into-teaching-app": ["production"]
+      "get-into-teaching-app": ["production"],
+      "get-into-teaching-interface-api": ["production"]
     },
     "sip": {
       "sap-public": ["production"],

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -200,7 +200,8 @@
     "git": {
       "schools-experience": ["review", "development", "staging"],
       "get-into-teaching-api": [ "review", "development", "test"],
-      "get-into-teaching-app": ["review", "development", "test"]
+      "get-into-teaching-app": ["review", "development", "test"],
+      "get-into-teaching-interface-api": ["review", "development", "test"]
     },
     "sip": {
       "sap-public": ["review", "test"],


### PR DESCRIPTION
## Context
Create federated credentials for each environment, as part of the onboarding process for the get-into-teaching-interface-api service. This will allow Terraform changes to be applied using Github workflows.

## Changes proposed in this pull request
Add new service and environments to existing config.

## Guidance to review
Review code changes to ensure they match the pattern of existing services.
Check the details in the attached screenshots of the Terraform plan being run against each cluster.

Test:
<img width="1416" height="447" alt="image" src="https://github.com/user-attachments/assets/716d001c-3106-4f24-8cef-03e672bffc7d" />

Production:
<img width="1416" height="258" alt="image" src="https://github.com/user-attachments/assets/6eaa6ff9-93cb-4cb5-9693-e7ddb7321e76" />

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
