### PR TITLE
Remove ingress smoke test

### DIFF
--- a/.github/actions/deploy-environment/action.yml
+++ b/.github/actions/deploy-environment/action.yml
@@ -87,9 +87,6 @@ runs:
   - name: Smoke tests
     shell: bash
     run: |
-      echo Check ingress...
-      curl -sS --fail "https://aaa.${APP_DOMAIN}/healthz" > /dev/null
-
       echo Check welcome app...
       curl -sS --fail "https://www.${APP_DOMAIN}/" > /dev/null
 


### PR DESCRIPTION
## Context
Remove ingress smoke test from the cluster deploy workflow, 
as it is no longer valid after the switch to traefik

## Changes proposed in this pull request
Remove from the github workflow

## Guidance to review
Check the code change looks ok

## After merging
Check the deploy workflow completes successfully

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
