### PR TITLE
add new gias edpweb and edpapi credentials

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -292,6 +292,10 @@
       "teaching-school-hub-finder": ["sandbox","production"],
       "teacher-training-entitlement": ["sandbox","production"]
     },
+    "gias": {
+      "education-provider-registry-integration-API": ["preproduction","production"],
+      "education-provider-registry-web": ["preproduction","production"]
+    },
     "git": {
       "schools-experience": ["production"],
       "get-into-teaching-api": ["production"],

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -195,7 +195,9 @@
       "teacher-training-entitlement": ["review", "development", "staging"]
     },
     "gias": {
-      "get-information-about-schools-api-prototype": ["development"]
+      "get-information-about-schools-api-prototype": ["development"],
+      "education-provider-registry-integration-API": ["development","review","test"],
+      "education-provider-registry-web": ["development","review","test"]
     },
     "git": {
       "schools-experience": ["review", "development", "staging"],


### PR DESCRIPTION
## Context
Trello: https://trello.com/c/D5U16T08/2803-onboard-gias-readapi
Create federated credentials for each gias epdweb and epdapi environment. This will allow Terraform changes to be applied using Github workflows.

## Changes proposed in this pull request
Add new service and environments to existing config.

## Guidance to review
Review code changes to ensure they match the pattern of existing services.
Check the details of the Terraform plan being run against each cluster.
from pr branch of teacher-services-cloud
`make test terraform-kubernetes-plan CONFIRM_TEST=yes`
changes should be creation of x6 federated credentials for environments _development, review and test_, each for edpweb and edpapi.

`make production terraform-kubernetes-plan CONFIRM_PRODUCTION=yes`
changes should be creation of x4 federated credentials for environments _production and preproduction_, each for edpweb and edpapi.

test cluster
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_federated_identity_credential.github_actions_wif["education-provider-registry-integration-API-development"] will be created
  + resource "azurerm_federated_identity_credential" "github_actions_wif" {
      + audience            = [
          + "api://AzureADTokenExchange",
        ]
      + id                  = (known after apply)
      + issuer              = "https://token.actions.githubusercontent.com"
      + name                = "education-provider-registry-integration-API-development"
      + parent_id           = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-tsc-ts-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s189t01-ga-wif-test-gias-id"
      + resource_group_name = (known after apply)
      + subject             = "repo:DFE-Digital/education-provider-registry-integration-API:environment:development"
    }

  # azurerm_federated_identity_credential.github_actions_wif["education-provider-registry-integration-API-review"] will be created
  + resource "azurerm_federated_identity_credential" "github_actions_wif" {
      + audience            = [
          + "api://AzureADTokenExchange",
        ]
      + id                  = (known after apply)
      + issuer              = "https://token.actions.githubusercontent.com"
      + name                = "education-provider-registry-integration-API-review"
      + parent_id           = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-tsc-ts-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s189t01-ga-wif-test-gias-id"
      + resource_group_name = (known after apply)
      + subject             = "repo:DFE-Digital/education-provider-registry-integration-API:environment:review"
    }

  # azurerm_federated_identity_credential.github_actions_wif["education-provider-registry-integration-API-test"] will be created
  + resource "azurerm_federated_identity_credential" "github_actions_wif" {
      + audience            = [
          + "api://AzureADTokenExchange",
        ]
      + id                  = (known after apply)
      + issuer              = "https://token.actions.githubusercontent.com"
      + name                = "education-provider-registry-integration-API-test"
      + parent_id           = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-tsc-ts-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s189t01-ga-wif-test-gias-id"
      + resource_group_name = (known after apply)
      + subject             = "repo:DFE-Digital/education-provider-registry-integration-API:environment:test"
    }

  # azurerm_federated_identity_credential.github_actions_wif["education-provider-registry-web-development"] will be created
  + resource "azurerm_federated_identity_credential" "github_actions_wif" {
      + audience            = [
          + "api://AzureADTokenExchange",
        ]
      + id                  = (known after apply)
      + issuer              = "https://token.actions.githubusercontent.com"
      + name                = "education-provider-registry-web-development"
      + parent_id           = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-tsc-ts-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s189t01-ga-wif-test-gias-id"
      + resource_group_name = (known after apply)
      + subject             = "repo:DFE-Digital/education-provider-registry-web:environment:development"
    }

  # azurerm_federated_identity_credential.github_actions_wif["education-provider-registry-web-review"] will be created
  + resource "azurerm_federated_identity_credential" "github_actions_wif" {
      + audience            = [
          + "api://AzureADTokenExchange",
        ]
      + id                  = (known after apply)
      + issuer              = "https://token.actions.githubusercontent.com"
      + name                = "education-provider-registry-web-review"
      + parent_id           = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-tsc-ts-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s189t01-ga-wif-test-gias-id"
      + resource_group_name = (known after apply)
      + subject             = "repo:DFE-Digital/education-provider-registry-web:environment:review"
    }

  # azurerm_federated_identity_credential.github_actions_wif["education-provider-registry-web-test"] will be created
  + resource "azurerm_federated_identity_credential" "github_actions_wif" {
      + audience            = [
          + "api://AzureADTokenExchange",
        ]
      + id                  = (known after apply)
      + issuer              = "https://token.actions.githubusercontent.com"
      + name                = "education-provider-registry-web-test"
      + parent_id           = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-tsc-ts-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s189t01-ga-wif-test-gias-id"
      + resource_group_name = (known after apply)
      + subject             = "repo:DFE-Digital/education-provider-registry-web:environment:test"
    }

Plan: 6 to add, 0 to change, 0 to destroy.
```

production cluster
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_federated_identity_credential.github_actions_wif["education-provider-registry-integration-API-preproduction"] will be created
  + resource "azurerm_federated_identity_credential" "github_actions_wif" {
      + audience            = [
          + "api://AzureADTokenExchange",
        ]
      + id                  = (known after apply)
      + issuer              = "https://token.actions.githubusercontent.com"
      + name                = "education-provider-registry-integration-API-preproduction"
      + parent_id           = (known after apply)
      + resource_group_name = (known after apply)
      + subject             = "repo:DFE-Digital/education-provider-registry-integration-API:environment:preproduction"
    }

  # azurerm_federated_identity_credential.github_actions_wif["education-provider-registry-integration-API-production"] will be created
  + resource "azurerm_federated_identity_credential" "github_actions_wif" {
      + audience            = [
          + "api://AzureADTokenExchange",
        ]
      + id                  = (known after apply)
      + issuer              = "https://token.actions.githubusercontent.com"
      + name                = "education-provider-registry-integration-API-production"
      + parent_id           = (known after apply)
      + resource_group_name = (known after apply)
      + subject             = "repo:DFE-Digital/education-provider-registry-integration-API:environment:production"
    }

  # azurerm_federated_identity_credential.github_actions_wif["education-provider-registry-web-preproduction"] will be created
  + resource "azurerm_federated_identity_credential" "github_actions_wif" {
      + audience            = [
          + "api://AzureADTokenExchange",
        ]
      + id                  = (known after apply)
      + issuer              = "https://token.actions.githubusercontent.com"
      + name                = "education-provider-registry-web-preproduction"
      + parent_id           = (known after apply)
      + resource_group_name = (known after apply)
      + subject             = "repo:DFE-Digital/education-provider-registry-web:environment:preproduction"
    }

  # azurerm_federated_identity_credential.github_actions_wif["education-provider-registry-web-production"] will be created
  + resource "azurerm_federated_identity_credential" "github_actions_wif" {
      + audience            = [
          + "api://AzureADTokenExchange",
        ]
      + id                  = (known after apply)
      + issuer              = "https://token.actions.githubusercontent.com"
      + name                = "education-provider-registry-web-production"
      + parent_id           = (known after apply)
      + resource_group_name = (known after apply)
      + subject             = "repo:DFE-Digital/education-provider-registry-web:environment:production"
    }

  # azurerm_user_assigned_identity.ga_wif["gias"] will be created
  + resource "azurerm_user_assigned_identity" "ga_wif" {
      + client_id           = (known after apply)
      + id                  = (known after apply)
      + location            = "uksouth"
      + name                = "s189p01-ga-wif-production-gias-id"
      + principal_id        = (known after apply)
      + resource_group_name = "s189p01-tsc-pd-rg"
      + tenant_id           = (known after apply)
    }

Plan: 5 to add, 0 to change, 0 to destroy.
```

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x ] I have attached the pull request to the trello card
