### PR TITLE
Removed development environment

### DIFF
--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -203,7 +203,7 @@
       "schools-experience": ["review", "development", "staging"],
       "get-into-teaching-api": [ "review", "development", "test"],
       "get-into-teaching-app": ["review", "development", "test"],
-      "get-into-teaching-interface-api": ["review", "development", "test"]
+      "get-into-teaching-interface-api": ["review", "test"]
     },
     "sip": {
       "sap-public": ["review", "test"],


### PR DESCRIPTION
## Context
Remove development environment that was included due to human error.

## Changes proposed in this pull request
Remove development environment included by mistake in previous PR.

## Guidance to review
Confirm that changes are only removing the development environment by reviewing the code.
Terraform has been run locally and produced the following plan:
<img width="2134" height="570" alt="image" src="https://github.com/user-attachments/assets/dae64926-5a54-40eb-a9d7-0142dd0a7c19" />

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
