### PR TITLE
Fix traefik cert dependency

### DIFF
--- a/cluster/terraform_kubernetes/traefik_ingress.tf
+++ b/cluster/terraform_kubernetes/traefik_ingress.tf
@@ -32,6 +32,10 @@ resource "helm_release" "traefik-ingress" {
     type  = "string"
   }
 
+  depends_on = [
+    kubernetes_secret_v1.kube_cert_secret_traefik
+  ]
+
 }
 
 resource "azurerm_public_ip" "ingress-public-ip-traefik" {


### PR DESCRIPTION
## Context
Traefik helm install has a dependency on the traefik cert

## Changes proposed in this pull request
Add dependency on the resource in terraform

## Guidance to review
deploy a dev cluster, and it should deploy successfully

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
