### PR TITLE
new service items Education Provider Registry Data

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -295,7 +295,8 @@
     },
     "gias": {
       "education-provider-registry-integration-API": ["preproduction","production"],
-      "education-provider-registry-web": ["preproduction","production"]
+      "education-provider-registry-web": ["preproduction","production"],
+      "education-provider-registry-data": ["preproduction","production"]
     },
     "git": {
       "schools-experience": ["production"],

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -198,7 +198,8 @@
     "gias": {
       "get-information-about-schools-api-prototype": ["development"],
       "education-provider-registry-integration-API": ["development","review","test"],
-      "education-provider-registry-web": ["development","review","test"]
+      "education-provider-registry-web": ["development","review","test"],
+      "education-provider-registry-data": ["development","review","test"]
     },
     "git": {
       "schools-experience": ["review", "development", "staging"],

--- a/templates/populated/education-provider-registry-data.env
+++ b/templates/populated/education-provider-registry-data.env
@@ -1,0 +1,10 @@
+SERVICE_NAME=education-provider-registry-data
+SERVICE_SHORT=eprdat
+SERVICE_PRETTY="Education Provider Registry (Data)"
+DOCKER_REPOSITORY="ghcr.io/dfe-digital/education-provider-registry-data"
+NAMESPACE_PREFIX=gias
+DNS_ZONE_NAME=notset
+ENVIRONMENTS="development test preproduction"
+POSTGRES="true"
+REDIS="false"
+RAILS_APPLICATION="false"


### PR DESCRIPTION
## Context

Onboarding new service Education Provider Registry - Data

## Changes proposed in this pull request
This change adds the managed identities to be used for the service and the template that was used to generate the new service.

## Guidance to review
Validate changes as expected for test and production, x5 new identities as per plan output attached:

`make test terraform-kubernetes-plan CONFIRM_TEST=yes`
`make production terraform-kubernetes-plan CONFIRM_PRODUCTION=yes`

For Test
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_federated_identity_credential.github_actions_wif["education-provider-registry-data-development"] will be created
  + resource "azurerm_federated_identity_credential" "github_actions_wif" {
      + audience            = [
          + "api://AzureADTokenExchange",
        ]
      + id                  = (known after apply)
      + issuer              = "https://token.actions.githubusercontent.com"
      + name                = "education-provider-registry-data-development"
      + parent_id           = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-tsc-ts-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s189t01-ga-wif-test-gias-id"
      + resource_group_name = (known after apply)
      + subject             = "repo:DFE-Digital/education-provider-registry-data:environment:development"
    }

  # azurerm_federated_identity_credential.github_actions_wif["education-provider-registry-data-review"] will be created
  + resource "azurerm_federated_identity_credential" "github_actions_wif" {
      + audience            = [
          + "api://AzureADTokenExchange",
        ]
      + id                  = (known after apply)
      + issuer              = "https://token.actions.githubusercontent.com"
      + name                = "education-provider-registry-data-review"
      + parent_id           = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-tsc-ts-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s189t01-ga-wif-test-gias-id"
      + resource_group_name = (known after apply)
      + subject             = "repo:DFE-Digital/education-provider-registry-data:environment:review"
    }

  # azurerm_federated_identity_credential.github_actions_wif["education-provider-registry-data-test"] will be created
  + resource "azurerm_federated_identity_credential" "github_actions_wif" {
      + audience            = [
          + "api://AzureADTokenExchange",
        ]
      + id                  = (known after apply)
      + issuer              = "https://token.actions.githubusercontent.com"
      + name                = "education-provider-registry-data-test"
      + parent_id           = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-tsc-ts-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s189t01-ga-wif-test-gias-id"
      + resource_group_name = (known after apply)
      + subject             = "repo:DFE-Digital/education-provider-registry-data:environment:test"
    }

Plan: 3 to add, 0 to change, 0 to destroy.
```

For Production
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_federated_identity_credential.github_actions_wif["education-provider-registry-data-preproduction"] will be created
  + resource "azurerm_federated_identity_credential" "github_actions_wif" {
      + audience            = [
          + "api://AzureADTokenExchange",
        ]
      + id                  = (known after apply)
      + issuer              = "https://token.actions.githubusercontent.com"
      + name                = "education-provider-registry-data-preproduction"
      + parent_id           = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tsc-pd-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s189p01-ga-wif-production-gias-id"
      + resource_group_name = (known after apply)
      + subject             = "repo:DFE-Digital/education-provider-registry-data:environment:preproduction"
    }

  # azurerm_federated_identity_credential.github_actions_wif["education-provider-registry-data-production"] will be created
  + resource "azurerm_federated_identity_credential" "github_actions_wif" {
      + audience            = [
          + "api://AzureADTokenExchange",
        ]
      + id                  = (known after apply)
      + issuer              = "https://token.actions.githubusercontent.com"
      + name                = "education-provider-registry-data-production"
      + parent_id           = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-tsc-pd-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/s189p01-ga-wif-production-gias-id"
      + resource_group_name = (known after apply)
      + subject             = "repo:DFE-Digital/education-provider-registry-data:environment:production"
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```
## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
