### PR TITLE
2823-Replace test environment credentials with qa

### DIFF
--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -205,7 +205,7 @@
       "schools-experience": ["review", "development", "staging"],
       "get-into-teaching-api": [ "review", "development", "test"],
       "get-into-teaching-app": ["review", "development", "test"],
-      "get-into-teaching-interface-api": ["review", "test"]
+      "get-into-teaching-interface-api": ["review", "qa"]
     },
     "sip": {
       "sap-public": ["review", "test"],


### PR DESCRIPTION
## Context
This change is to replace the "test" environment credentials for the get-into-teaching-interface-api service with the correct "qa" environment credentials.

## Changes proposed in this pull request
Remove federated credentials for "test" on s189t01-ga-wif-test-git-id managed identity
Create federated credentials for "qa" on s189t01-ga-wif-test-git-id managed identity 

## Guidance to review
Run "make test terraform-plan CONFIRM_TEST=yes" to generate terraform plan.
Review output from terraform plan:
<img width="1374" height="484" alt="image" src="https://github.com/user-attachments/assets/332452c1-9df2-4164-84f0-e16f4d9283df" />

## Before merging
Confirm plan creates and destroys the expected federated credentials.

## After merging
Confirm the expected credentials appear in the Azure portal for s189t01-ga-wif-test-git-id managed identity 

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
