### PR TITLE
upgrades kube-state-metrics for aks 1.35 upgrade

### DIFF
--- a/.ghcr_cache_images.yml
+++ b/.ghcr_cache_images.yml
@@ -23,4 +23,5 @@ registry.k8s.io/ingress-nginx/controller:v1.13.4 nginx-controller-v1.13.4
 registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0 kube-state-metrics-v2.15.0
 registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0 kube-state-metrics-v2.17.0
 registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0 kube-state-metrics-v2.18.0
+registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.19.1 kube-state-metrics-v2.19.1
 quay.io/thanos/thanos:v0.39.2 thanos-v0.39.2


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
Adds kube-state-metrics 2.19.1 to the ghcr cache, required as part of the AKS upgrade to k8s 1.35.x

## Changes proposed in this pull request
Make the kube-state-metrics image for 2.19.1 available from the ghcr cache

## Guidance to review
Can only be tested after merge to prove that kube-state-metrics can be pulled by AKS

## Before merging
N/A

## After merging


## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
