### PR TITLE
Upgrades the development cluster to K8S version 1.35.5

### DIFF
--- a/cluster/terraform_aks_cluster/config/development.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/development.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.34.6",
+  "kubernetes_version": "1.35.5",
   "default_node_pool": {
     "node_count": 1,
-    "orchestrator_version": "1.34.6",
+    "orchestrator_version": "1.35.5",
     "max_surge": 1,
     "drain_timeout_in_minutes": 15,
     "node_soak_duration_in_minutes": 1
@@ -15,7 +15,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.34.6",
+      "orchestrator_version": "1.35.5",
       "max_surge": 1,
       "drain_timeout_in_minutes": 15,
       "node_soak_duration_in_minutes": 1

--- a/cluster/terraform_kubernetes/config/development.tfvars.json
+++ b/cluster/terraform_kubernetes/config/development.tfvars.json
@@ -21,7 +21,7 @@
   "thanos_retention_1h": "12d",
   "cluster_short": "dv",
   "block_metrics_endpoint" : false,
-  "kube_state_metrics_version": "2.18.0",
+  "kube_state_metrics_version": "2.19.1",
   "ga_wif_managed_id": {
     "bat": {
       "itt-mentor-services": ["dv_review"]


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
Upgrades the Development AKS cluster to Kubernetes version 1.35.5

## Changes proposed in this pull request
Upgrades Kubernetes versions on control plane and node groups to version 1.35.5
Upgrades kube-state-metrics to version 2.19.1 to bring in line with supported Kubernetes version 

## Guidance to review
Pull this branch and deploy a dev cluster confirm that it deploys as version 1.35.5 

## Before merging

## After merging

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
