### PR TITLE
Use env.HEALTHCHECK_CMD for healthcheck probe for deploy env domains job in template …

### DIFF
--- a/templates/new_service/.github/workflows/build-and-deploy.yml
+++ b/templates/new_service/.github/workflows/build-and-deploy.yml
@@ -218,6 +218,6 @@ jobs:
 #        azure-tenant-id:  ${{ secrets.AZURE_TENANT_ID   }}
 #        azure-subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
 #        environment: ${{ matrix.domain_environment }}
-#        healthcheck: healthcheck
+#        healthcheck: ${{ env.HEALTHCHECK_CMD }}
 #        teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
 #        service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}


### PR DESCRIPTION
## Context
The updated file is a template used by the new_service script to create new workflows for new services. Healthchecks are performed at various stages of the deployment workflow using a base URL plus path defined either explicitly in the job or env.HEALTHCHECK_CMD.  This change will standardise use of Healthcheck path so env.HEALTHCHECK_CMD is used in all jobs (as opposed to explicit values for deploy_domains_env job)

## Changes proposed in this pull request
- Use env.HEALTHCHECK_CMD for Deploy Domains Environment job in Deploy workflow
 
## Guidance to review
Sense check the use, does it make sense to use here as is used in other locations or will the value differ for some reason?

run `make new_service` to generate new service config, ensure that `templates\new_service\.github\workflows\build-and-deploy.yml` contains the changed value and is produced correctly.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
