### PR TITLE
Upgrades test cluster to 1.35.5

### DIFF
--- a/cluster/terraform_aks_cluster/config/test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/test.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.34.6",
+  "kubernetes_version": "1.35.5",
   "default_node_pool": {
     "node_count": 2,
-    "orchestrator_version": "1.34.6",
+    "orchestrator_version": "1.35.5",
     "max_surge": 1,
     "drain_timeout_in_minutes": 15,
     "node_soak_duration_in_minutes": 1
@@ -16,7 +16,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.34.6",
+      "orchestrator_version": "1.35.5",
       "max_surge": 3,
       "drain_timeout_in_minutes": 15,
       "node_soak_duration_in_minutes": 1

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -45,7 +45,7 @@
     "tv-development",
     "tv-staging"
   ],
-  "kube_state_metrics_version": "2.18.0",
+  "kube_state_metrics_version": "2.19.1",
   "cluster_kv": "s189t01-tsc-ts-kv",
   "ingress_cert_name": "test-teacherservices-cloud-2",
   "statuscake_alerts": {


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
Upgrades test AKS cluster to version 1.35.5

## Changes proposed in this pull request
Upgrades AKS control plane and worker nodes to kubernetes 1.35.5
Upgades kube-state-metrics to 2.19.1

## Guidance to review
Can be confirmed via the console that test cluster is now 1.35.5

## Before merging


## After merging


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
