### PR TITLE
2845 - Applies selective options fix to new_service

### DIFF
--- a/templates/new_service.sh
+++ b/templates/new_service.sh
@@ -84,22 +84,38 @@ done
 export OPTIONS_BLOCK="$options_block"
 
 awk '
-/^        options:[[:space:]]*$/ {
-  print
-  printf "%s", ENVIRON["OPTIONS_BLOCK"]
-  skip=1
-  next
+# Enter the environment input section
+/^[[:space:]]*environment:[[:space:]]*$/ {
+    in_environment=1
 }
 
-skip && /^        - / {
-  next
+# Leave the environment input section when mode is reached
+in_environment && /^[[:space:]]*mode:[[:space:]]*$/ {
+    in_environment=0
 }
 
+# Replace only the options block belonging to environment
+in_environment && /^[[:space:]]*options:[[:space:]]*$/ {
+    print
+    printf "%s", ENVIRON["OPTIONS_BLOCK"]
+    skip=1
+    next
+}
+
+# While skipping, discard existing list items
+skip && /^[[:space:]]*-[[:space:]]/ {
+    next
+}
+
+# First non-list line after the options block
 skip {
-  skip=0
+    skip=0
 }
 
-{ print }
+# Print all remaining lines
+{
+    print
+}
 ' templates/new_service/.github/workflows/maintenance.yml > tmp.yml \
   && mv tmp.yml new_service/.github/workflows/maintenance.yml
 


### PR DESCRIPTION
## Context
The [new_service ](https://github.com/DFE-Digital/teacher-services-cloud/blob/main/templates/new_service.sh)script produces **.github\workflows\maintenance.yml** with incorrect mode options. Workflows using this will fail.

## Changes proposed in this pull request
It appears that the code in the AWK block is replacing any lists that begin with `options:` with the contents of _OPTIONS_BLOCK_.

The changes in this PR amend the AWK block to be more selective around which `options:` to replace; it should overwrite only that list within `environments`, leaving that within `mode` untouched.

## Guidance to review
Edit the environments to be deployed in the **teacher-services-cloud/templates/new_service_parameters.env** file. It will always deploy a **review** and **production** environment as these are mandatory.
As per the documentation, build out the new service directory structure and contents using the following command:

```make new_service```

Compare the contents with an existing service (such as https://github.com/DFE-Digital/education-provider-registry-web) to determine whether it was deployed successfully, noting the environments you specified to be deployed in particular. The structure of the deployment should be similar.

Now, in your newly deployed service structure, open the **.github\workflows\maintenance.yml** file to double-check that the `environments` section contains the correct contents, and that the `mode` block only contains `enable` and `disable`.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
