### PR TITLE
Upgrades production AKS cluster to 1.35.5

### DIFF
--- a/cluster/terraform_aks_cluster/config/production.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/production.tfvars.json
@@ -1,9 +1,9 @@
 {
   "cip_tenant": true,
-  "kubernetes_version": "1.34.6",
+  "kubernetes_version": "1.35.5",
   "default_node_pool": {
     "node_count": 3,
-    "orchestrator_version": "1.34.6",
+    "orchestrator_version": "1.35.5",
     "max_surge": 1,
     "drain_timeout_in_minutes": 15,
     "node_soak_duration_in_minutes": 1
@@ -16,7 +16,7 @@
       "node_labels": {
         "teacherservices.cloud/node_pool": "applications"
       },
-      "orchestrator_version": "1.34.6",
+      "orchestrator_version": "1.35.5",
       "max_surge": 3,
       "drain_timeout_in_minutes": 15,
       "node_soak_duration_in_minutes": 1

--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -26,7 +26,7 @@
     "tra-production",
     "tv-production"
   ],
-  "kube_state_metrics_version": "2.18.0",
+  "kube_state_metrics_version": "2.19.1",
   "cluster_kv": "s189p01-tsc-pd-kv",
   "statuscake_alerts": {
     "tscluster-production": {


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
Upgrades Production AKS cluster to 1.35.5

## Changes proposed in this pull request
Upgrades production AKS cluster control plane and worker nodes to Kubernetes version 1.35.5
Upgrades kube-state-metrics to version 2.19.1

## Guidance to review
Can confirm in the Azure console that cluster and nodes are now Kubernetes v1.35.5

## Before merging
<!-- Any extra steps like: delete temp commit, send warning, wait after office hours... -->

## After merging
<!-- Any extra steps like: update other PR, apply manually, inform someone... -->

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
