### PR TITLE
Add Validate Infra workflow to new_service template

### DIFF
--- a/templates/new_service/.github/workflows/validate-infrastructure.yml
+++ b/templates/new_service/.github/workflows/validate-infrastructure.yml
@@ -1,0 +1,43 @@
+name: Validate Infra
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: ${{ matrix.display }}
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - display: AKS infrastructure
+            validation_plan: aks-infra
+            terraform_base: config/terraform/application
+          - display: Domains infrastructure
+            validation_plan: domains-infra
+            terraform_base: config/terraform/domains/infrastructure
+          - display: Domains environment
+            validation_plan: domains-env
+            terraform_base: config/terraform/domains/environment_domains
+
+    steps:
+      - name: Validate ${{ matrix.display }}
+        uses: DFE-Digital/github-actions/validate-infra@master
+        with:
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          environment: production
+          terraform-base: ${{ matrix.terraform_base }}
+          validation-plan: ${{ matrix.validation_plan }}
+          service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
+          teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL_INFRA }}
+          #gcp-wip:
+          #gcp-project-id:

--- a/templates/new_service/.github/workflows/validate-infrastructure.yml
+++ b/templates/new_service/.github/workflows/validate-infrastructure.yml
@@ -19,13 +19,13 @@ jobs:
         include:
           - display: AKS infrastructure
             validation_plan: aks-infra
-            terraform_base: config/terraform/application
+            terraform_base: terraform/application
           - display: Domains infrastructure
             validation_plan: domains-infra
-            terraform_base: config/terraform/domains/infrastructure
+            terraform_base: terraform/domains/infrastructure
           - display: Domains environment
             validation_plan: domains-env
-            terraform_base: config/terraform/domains/environment_domains
+            terraform_base: terraform/domains/environment_domains
 
     steps:
       - name: Validate ${{ matrix.display }}


### PR DESCRIPTION
## Context
Adding standard workflow to new_service templates so that it will be used for new service setups as standard.

## Changes proposed in this pull request
- Add templates/new_service/.github/workflows/validate-infrastructure.yml

## Guidance to review
- ensure `make new_service` produces `new_service\.github\workflows\validate-infrastructure.yml`
- ensure the produced file is appropriate as a standard template for infra validation workflows

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
