### PR TITLE
adds logstash image to ghcr cache

### DIFF
--- a/.ghcr_cache_images.yml
+++ b/.ghcr_cache_images.yml
@@ -1,5 +1,6 @@
 prom/node-exporter:v1.9.1 node-exporter-v1.9.1
 docker.elastic.co/beats/filebeat-oss:8.19.9 filebeat-oss-8.19.9
+docker.elastic.co/logstash/logstash:8.19.9 logstash-8.19.9
 nginxinc/nginx-unprivileged:1.27.3-alpine3.20 nginx-unprivileged-1.27.3-alpine3.20
 nginxinc/nginx-unprivileged:1.27.5-alpine3.21 nginx-unprivileged-1.27.5-alpine3.21
 postgres:13-alpine postgres-13-alpine


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
As part of sending logs to DFE Splunk Logstash is required as log router, this PR adds the Logstash image to ghcr cache.

## Changes proposed in this pull request
Adds Logstash image for version 8.19.9 to ghcr cache

## Guidance to review
Once the image is added to cache attempt to pull from ghcr

## Before merging
<!-- Any extra steps like: delete temp commit, send warning, wait after office hours... -->

## After merging
<!-- Any extra steps like: update other PR, apply manually, inform someone... -->

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
