### PR TITLE
Add traefik IP for the test cluster

### DIFF
--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -238,5 +238,6 @@
     "tv": {
       "teaching-vacancies": ["review", "qa", "staging"]
     }
-  }
+  },
+  "add_traefik_ingress_ip": true
 }


### PR DESCRIPTION
## Context
First step for enabling traefik in the test cluster 

## Changes proposed in this pull request
Add ingress PIP
traefik not enabled at this point

## Guidance to review
make test terraform-kubernetes-plan

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
