### PR TITLE
Added namespaces for SEND development, test, and production

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -10,6 +10,7 @@
     "infra",
     "monitoring",
     "schoolstandards-production",
+    "send-production",
     "sip-production",
     "srtl-production",
     "tra-production",

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -16,6 +16,8 @@
     "monitoring",
     "schoolstandards-development",
     "schoolstandards-test",
+    "send-development",
+    "send-test",
     "sip-development",
     "sip-test",
     "srtl-development",


### PR DESCRIPTION
## Context
Add namespaces for SEND services in preparation for service onboarding

## Changes proposed in this pull request
Add values to kubernetes variables to add namespaces for SEND environments

## Guidance to review
Run the following commands and/or review the following screenshots:
make test terraform-plan CONFIRM_TEST=yes
<img width="524" height="426" alt="image" src="https://github.com/user-attachments/assets/3c128e9e-42ae-4d01-be78-87b0fa91b5de" />

make production terraform-plan CONFIRM_PRODUCTION=yes
<img width="530" height="244" alt="image" src="https://github.com/user-attachments/assets/c77d2f8f-8e59-4bf1-8f6a-d4f6c878dc65" />

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
