### PR TITLE
Scheduled node OS upgrades for development and platform-test

### DIFF
--- a/cluster/terraform_aks_cluster/config/development.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/development.tfvars.json
@@ -1,6 +1,7 @@
 {
   "cip_tenant": true,
   "kubernetes_version": "1.35.5",
+  "node_upgrade_channel": "NodeImage",
   "default_node_pool": {
     "node_count": 1,
     "orchestrator_version": "1.35.5",
@@ -21,5 +22,14 @@
       "node_soak_duration_in_minutes": 1
     }
   },
-  "admin_group_id": "f77b2daf-7ff4-4aa5-8138-cf983d0b4a18"
+  "admin_group_id": "f77b2daf-7ff4-4aa5-8138-cf983d0b4a18",
+  "node_upgrade_maintenance_window": {
+    "frequency": "RelativeMonthly",
+    "interval": "1",
+    "duration": "8",
+    "day_of_week": "Sunday",
+    "week_index": "First",
+    "start_time": "23:59",
+    "utc_offset": "+01:00"
+  }
 }

--- a/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/platform-test.tfvars.json
@@ -1,6 +1,7 @@
 {
   "cip_tenant": true,
   "kubernetes_version": "1.35.5",
+  "node_upgrade_channel": "NodeImage",
   "default_node_pool": {
     "node_count": 2,
     "orchestrator_version": "1.35.5",
@@ -21,5 +22,14 @@
       "node_soak_duration_in_minutes": 1
     }
   },
-  "admin_group_id": "f726cc54-78cb-4c98-89a6-b8e4396afb98"
+  "admin_group_id": "f726cc54-78cb-4c98-89a6-b8e4396afb98",
+  "node_upgrade_maintenance_window": {
+    "frequency": "RelativeMonthly",
+    "interval": "1",
+    "duration": "8",
+    "day_of_week": "Sunday",
+    "week_index": "Second",
+    "start_time": "23:59",
+    "utc_offset": "+01:00"
+  }
 }

--- a/cluster/terraform_aks_cluster/main.tf
+++ b/cluster/terraform_aks_cluster/main.tf
@@ -18,7 +18,16 @@ resource "azurerm_kubernetes_cluster" "main" {
   workload_identity_enabled = true
 
   image_cleaner_interval_hours = 48
-  node_os_upgrade_channel      = "None"
+  node_os_upgrade_channel      = var.node_upgrade_channel
+  maintenance_window_node_os {
+    frequency   = var.node_upgrade_maintenance_window.frequency
+    interval    = var.node_upgrade_maintenance_window.interval
+    duration    = var.node_upgrade_maintenance_window.duration
+    day_of_week = var.node_upgrade_maintenance_window.day_of_week
+    week_index  = var.node_upgrade_maintenance_window.week_index
+    start_time  = var.node_upgrade_maintenance_window.start_time
+    utc_offset  = var.node_upgrade_maintenance_window.utc_offset
+  }
 
   dynamic "azure_active_directory_role_based_access_control" {
     for_each = var.enable_azure_RBAC ? [1] : []

--- a/cluster/terraform_aks_cluster/main.tf
+++ b/cluster/terraform_aks_cluster/main.tf
@@ -19,14 +19,17 @@ resource "azurerm_kubernetes_cluster" "main" {
 
   image_cleaner_interval_hours = 48
   node_os_upgrade_channel      = var.node_upgrade_channel
-  maintenance_window_node_os {
-    frequency   = var.node_upgrade_maintenance_window.frequency
-    interval    = var.node_upgrade_maintenance_window.interval
-    duration    = var.node_upgrade_maintenance_window.duration
-    day_of_week = var.node_upgrade_maintenance_window.day_of_week
-    week_index  = var.node_upgrade_maintenance_window.week_index
-    start_time  = var.node_upgrade_maintenance_window.start_time
-    utc_offset  = var.node_upgrade_maintenance_window.utc_offset
+  dynamic "maintenance_window_node_os" {
+    for_each = var.node_upgrade_channel != "None" ? [1] : []
+    content {
+      frequency   = var.node_upgrade_maintenance_window.frequency
+      interval    = var.node_upgrade_maintenance_window.interval
+      duration    = var.node_upgrade_maintenance_window.duration
+      day_of_week = var.node_upgrade_maintenance_window.day_of_week
+      week_index  = var.node_upgrade_maintenance_window.week_index
+      start_time  = var.node_upgrade_maintenance_window.start_time
+      utc_offset  = var.node_upgrade_maintenance_window.utc_offset
+    }
   }
 
   dynamic "azure_active_directory_role_based_access_control" {

--- a/cluster/terraform_aks_cluster/variables.tf
+++ b/cluster/terraform_aks_cluster/variables.tf
@@ -55,6 +55,18 @@ variable "second_egress_ip" {
   description = "Allocate a second egress public IP for the cluster"
 }
 
+variable "node_upgrade_channel" {
+  type        = string
+  default     = "None"
+  description = "Upgrade channel for automatic node OS updates"
+}
+
+variable "node_upgrade_maintenance_window" {
+  type        = map
+  default     = {}
+  description = "Schedule for automatic node OS updates"
+}
+
 locals {
   backing_services_resource_group_name = "${var.resource_prefix}-tsc-${var.environment}-bs-rg"
   cluster_name = (

--- a/cluster/terraform_aks_cluster/variables.tf
+++ b/cluster/terraform_aks_cluster/variables.tf
@@ -62,7 +62,7 @@ variable "node_upgrade_channel" {
 }
 
 variable "node_upgrade_maintenance_window" {
-  type        = map
+  type        = map(any)
   default     = {}
   description = "Schedule for automatic node OS updates"
 }


### PR DESCRIPTION
## Context
New feature to test automatic node OS updates

## Changes proposed in this pull request
Updates the development and platform-test environments to use the NodeImage upgrade channel, and schedules them to run on the first and second Sunday of each month.

## Guidance to review
Run the following commands locally and/or review the following screenshots of the plans:

make platform-test get-cluster-credentials CONFIRM_PLATFORM_TEST=yes
make platform-test terraform-plan CONFIRM_PLATFORM_TEST=yes
<img width="561" height="425" alt="image" src="https://github.com/user-attachments/assets/c738b200-c62d-469b-944d-cc09bf0baa66" />

make development terraform-plan ENVIRONMENT=cluster<2/3/4/6>
<img width="514" height="293" alt="image" src="https://github.com/user-attachments/assets/17c777d2-318c-4cd0-86b1-f6c3e828d375" />
<img width="285" height="152" alt="image" src="https://github.com/user-attachments/assets/32e24a65-c203-4871-9616-990c234601cf" />

Review the settings on cluster5 which has already been deployed:
<img width="810" height="212" alt="image" src="https://github.com/user-attachments/assets/874707db-a159-45ed-80cb-d5c6ce0e8bac" />

Run plans against test or prod to confirm no changes to these environments

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
