### PR TITLE
2855 - Adds review app deletion workflow to new_service

### DIFF
--- a/templates/new_service/.github/workflows/review-app-reconcile.yml
+++ b/templates/new_service/.github/workflows/review-app-reconcile.yml
@@ -1,0 +1,115 @@
+name: Reconcile review apps on AKS
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Only display stale review apps; do not delete"
+        required: true
+        default: true
+        type: boolean
+  schedule:
+    - cron: "0 08 * * 0"
+
+permissions:
+  id-token: write
+  pull-requests: write
+  contents: read
+
+env:
+  GLOBAL_CONFIG_PATH: global_config
+  TF_VARS_PATH: terraform/application/config
+  TERRAFORM_BASE: terraform/application
+  SERVICE_NAME: #SERVICE_NAME#
+  RESOURCE_GROUP_NAME: #RESOURCE_GROUP_NAME#
+  STORAGE_ACCOUNT_NAME: #STORAGE_ACCOUNT_NAME#
+  CONTAINER_NAME: terraform-state
+
+jobs:
+  display-review-apps-to-remove:
+    name: Reconcile review apps
+    runs-on: ubuntu-latest
+
+    environment: review
+
+    outputs:
+      stale_prs: ${{ steps.reconcile.outputs.stale_prs }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Reconcile review apps
+        id: reconcile
+        uses: DFE-Digital/github-actions/review-app-reconcile@master
+        with:
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          resource-group-name: ${{ env.RESOURCE_GROUP_NAME }}
+          storage-account-name: ${{ env.STORAGE_ACCOUNT_NAME }}
+          terraform-base: ${{ env.TERRAFORM_BASE }}
+          service-name: ${{ env.SERVICE_NAME }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-repo: ${{ github.repository }}
+          tf-vars-path: ${{ env.TF_VARS_PATH }}
+          global-config-path: ${{ env.GLOBAL_CONFIG_PATH }}
+
+  delete-review-apps-after-reconcile:
+    name: Delete review app ${{ matrix.pr_number }} after reconcile
+    needs: display-review-apps-to-remove
+    runs-on: ubuntu-latest
+    environment: review
+
+    if: >
+      (
+        github.event_name == 'schedule' ||
+        github.event.inputs.dry_run == 'false'
+      ) &&
+      needs.display-review-apps-to-remove.outputs.stale_prs != '[]'
+
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        pr_number: ${{ fromJson(needs.display-review-apps-to-remove.outputs.stale_prs) }}
+
+    concurrency: deploy_review_${{ matrix.pr_number }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: set PR_NUMBER
+        id: config
+        run: |
+          PR_NUMBER=${{ matrix.pr_number }}
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+          echo "ENVIRONMENT=pr-${PR_NUMBER}" >> $GITHUB_ENV
+
+      - name: Set environment variables
+        shell: bash
+        run: |
+          source global_config/review.sh
+          echo "AZURE_RESOURCE_PREFIX=${AZURE_RESOURCE_PREFIX}" >> $GITHUB_ENV
+          echo "CONFIG_SHORT=${CONFIG_SHORT}" >> $GITHUB_ENV
+
+      - name: Delete stale review app
+        uses: DFE-Digital/github-actions/delete-review-app@master
+        env:
+          PULL_REQUEST_NUMBER: ${{ matrix.pr_number }}
+        with:
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          gcp-wip: ${{ vars.GCP_WIP }}
+          gcp-project-id: ${{ vars.GCP_PROJECT_ID }}
+          pr-number: ${{ matrix.pr_number }}
+          resource-group-name: "${{ env.RESOURCE_GROUP_NAME }}"
+          storage-account-name: "${{ env.STORAGE_ACCOUNT_NAME }}"
+          container-name: ${{ env.CONTAINER_NAME }}
+          tf-state-file: "pr-${{ matrix.pr_number }}_kubernetes.tfstate"


### PR DESCRIPTION
## Context

BUG FIX: We get quite a few rogue review apps - i.e., the PR has been merged or closed, but the review app wasn’t deleted.

There are various reasons this can occur, but we now require a workflow that will check for rogue review apps and delete them on a scheduled basis. We require it to be run every Sunday.

## Changes proposed in this pull request

The **review-app-reconcile** workflow has been added to all relevant existing services, but also needs adding to any new service that is deployed. This PR offers that solution.

The code can be found here: [Review app reconcile](https://github.com/DFE-Digital/teacher-services-cloud/blob/2855-add-review-app-workflow-to-new-service/templates/new_service/.github/workflows/review-app-reconcile.yml)

## Guidance to review

This can only truly be tested when a new service is deployed, but the code follows the exact same structure as all other existing deployments.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the [Trello card](https://trello.com/c/ZWznDc8Y/2855-add-review-app-cleanup-workflow)
