### PR TITLE
Adds components required for logging to Splunk

### DIFF
--- a/cluster/terraform_kubernetes/config/development.tfvars.json
+++ b/cluster/terraform_kubernetes/config/development.tfvars.json
@@ -34,5 +34,7 @@
   "ingress_nginx_replicaCount": 0,
   "enable_nginx": false,
   "add_nginx_ingress_ip": false,
-  "create_nginx_ingressclass": true
+  "create_nginx_ingressclass": true,
+  "enable_splunk_logging": true,
+  "logstash_replica_count": 1
 }

--- a/cluster/terraform_kubernetes/config/filebeat/filebeat-splunk.yml.tmpl
+++ b/cluster/terraform_kubernetes/config/filebeat/filebeat-splunk.yml.tmpl
@@ -1,0 +1,41 @@
+filebeat.autodiscover:
+  providers:
+      - type: kubernetes
+        templates:
+          - condition:
+              equals:
+                kubernetes.annotations.splunk/send: "true"
+            config:
+              - type: container
+                paths:
+                  - "/var/log/containers/*-${data.kubernetes.container.id}.log"
+        add_resource_metadata:
+          node:
+            enabled: false
+          deployment: true
+
+# Global processors run AFTER enrichment and after all inputs
+processors:
+  - drop_fields:
+      fields:
+      - agent.ephemeral_id
+      - agent.id
+      - agent.name
+      - agent.version
+      - agent.type
+      - ecs.version
+      - container.runtime
+      - container.id
+      - host.name
+      - kubernetes.pod.uid
+      - kubernetes.namespace_uid
+      - kubernetes.labels
+      - kubernetes.namespace_labels.kubernetes_io/metadata_name
+      - log.offset
+      - log.file.path
+      - input.type
+
+output.logstash:
+  hosts: ["logstash.monitoring.svc.cluster.local:5044"]
+  loadbalance: true
+  ssl.enabled: false

--- a/cluster/terraform_kubernetes/config/filebeat/filebeat-splunk.yml.tmpl
+++ b/cluster/terraform_kubernetes/config/filebeat/filebeat-splunk.yml.tmpl
@@ -9,6 +9,7 @@ filebeat.autodiscover:
               - type: container
                 paths:
                   - "/var/log/containers/*-${data.kubernetes.container.id}.log"
+                tail_files: true
         add_resource_metadata:
           node:
             enabled: false

--- a/cluster/terraform_kubernetes/config/logstash/logstash.yml.tmpl
+++ b/cluster/terraform_kubernetes/config/logstash/logstash.yml.tmpl
@@ -1,0 +1,6 @@
+api.http.host: "0.0.0.0"
+api.http.port: 9600
+monitoring.enabled: false
+
+
+

--- a/cluster/terraform_kubernetes/config/logstash/pipeline.conf.tmpl
+++ b/cluster/terraform_kubernetes/config/logstash/pipeline.conf.tmpl
@@ -1,0 +1,17 @@
+input {
+  beats {
+    port => 5044
+  }
+}
+
+filter {
+}
+
+output {
+  http  {
+    content_type => "application/json"
+    http_method => "post"
+    url => "${SPLUNK_EVENTS_URL}"
+    headers => ["Authorization", "Splunk ${SPLUNK_EVENTS_TOKEN}"]
+  }
+}

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -82,6 +82,8 @@
   "thanos_compactor_disk": 512,
   "thanos_app_cpu": "0.5",
   "cluster_short": "ts",
+  "enable_splunk_logging": true,
+  "logstash_replica_count": 1,
   "alertable_apps": {
     "bat-qa/apply-qa": {
       "receiver": "TEAMS_WEBHOOK_ATT"

--- a/cluster/terraform_kubernetes/config/traefik/development.values.yaml
+++ b/cluster/terraform_kubernetes/config/traefik/development.values.yaml
@@ -76,6 +76,7 @@ deployment:
     # prometheus.io/scrape: "true"
     # prometheus.io/path: "/metrics"
     logit.io/send: "true"
+    splunk/send: "true"
     fluentbit.io/exclude: "true"
 
   # readinessPath: "/ping"

--- a/cluster/terraform_kubernetes/filebeat_splunk.tf
+++ b/cluster/terraform_kubernetes/filebeat_splunk.tf
@@ -1,0 +1,138 @@
+resource "kubernetes_config_map" "filebeat_splunk" {
+  count = var.enable_splunk_logging ? 1 : 0
+
+  metadata {
+    name      = "filebeat-splunk"
+    namespace = kubernetes_namespace.default_list["monitoring"].metadata[0].name
+  }
+
+  data = {
+    "filebeat.yml" = local.fb_splunk_config_map_data
+  }
+
+}
+
+locals {
+  fb_splunk_config_map_data = file("${path.module}/config/filebeat/filebeat-splunk.yml.tmpl")
+#   ls_config_map_hash = sha1(local.ls_config_map_data)
+}
+
+resource "kubernetes_daemonset" "filebeat_splunk" {
+  count = var.enable_splunk_logging ? 1 : 0
+
+  metadata {
+    name      = "filebeat-splunk"
+    namespace = kubernetes_namespace.default_list["monitoring"].metadata[0].name
+    labels = {
+      app = "filebeat"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels = {
+        app = "filebeat-splunk"
+      }
+    }
+
+
+    template {
+      metadata {
+        labels = {
+          app = "filebeat-splunk"
+        }
+        annotations = {
+          "fluentbit.io/exclude" = "true"
+        }
+      }
+
+      spec {
+        service_account_name             = kubernetes_service_account.filebeat.metadata[0].name
+        termination_grace_period_seconds = 30
+
+        node_selector = {
+          "teacherservices.cloud/node_pool" = "applications"
+          "kubernetes.io/os"                = "linux"
+        }
+
+        container {
+          image = "${var.tsc_package_repo}:${var.filebeat_image}-${var.filebeat_version}"
+          name  = "filebeat-splunk"
+
+          args = [
+            "-c",
+            "filebeat.yml",
+            "-e",
+          ]
+
+          security_context {
+            run_as_user = 0
+
+
+            capabilities {
+              drop = ["ALL"]
+            }
+            allow_privilege_escalation = false
+            privileged                 = false
+            run_as_non_root            = false
+            read_only_root_filesystem  = true
+          }
+
+          resources {
+            limits = {
+              cpu    = "200m"
+              memory = "300Mi"
+            }
+            requests = {
+              cpu    = "100m"
+              memory = "100Mi"
+            }
+          }
+
+          volume_mount {
+            mount_path = "/usr/share/filebeat/filebeat.yml"
+            name       = "filebeat-config"
+            read_only  = "true"
+            sub_path   = "filebeat.yml"
+          }
+
+          volume_mount {
+            mount_path = "/usr/share/filebeat/data"
+            name       = "data"
+          }
+
+          volume_mount {
+            mount_path = "/var/log"
+            name       = "varlog"
+            read_only  = "true"
+          }
+
+        }
+
+        volume {
+          name = "filebeat-config"
+          config_map {
+            name         = kubernetes_config_map.filebeat_splunk[0].metadata[0].name
+            default_mode = "0644"
+          }
+        }
+
+        volume {
+          name = "varlog"
+          host_path {
+            path = "/var/log"
+          }
+        }
+
+        volume {
+          name = "data"
+          host_path {
+            path = "/var/lib/filebeat-splunk-data"
+            type = "DirectoryOrCreate"
+          }
+        }
+
+      }
+    }
+  }
+}

--- a/cluster/terraform_kubernetes/filebeat_splunk.tf
+++ b/cluster/terraform_kubernetes/filebeat_splunk.tf
@@ -14,7 +14,7 @@ resource "kubernetes_config_map" "filebeat_splunk" {
 
 locals {
   fb_splunk_config_map_data = file("${path.module}/config/filebeat/filebeat-splunk.yml.tmpl")
-#   ls_config_map_hash = sha1(local.ls_config_map_data)
+  #   ls_config_map_hash = sha1(local.ls_config_map_data)
 }
 
 resource "kubernetes_daemonset" "filebeat_splunk" {

--- a/cluster/terraform_kubernetes/logstash.tf
+++ b/cluster/terraform_kubernetes/logstash.tf
@@ -1,0 +1,223 @@
+data "azurerm_key_vault_secret" "splunk_events_url" {
+  name         = "SPLUNK-URL-EVENTS"
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+}
+
+data "azurerm_key_vault_secret" "splunk_events_token" {
+  name         = "SPLUNK-EVENTS-TOKEN"
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+}
+
+resource "kubernetes_service_account" "logstash" {
+  count = var.enable_splunk_logging ? 1 : 0
+  metadata {
+    name      = "logstash"
+    namespace = kubernetes_namespace.default_list["monitoring"].metadata[0].name
+    labels = {
+      "name" = "logstash"
+    }
+  }
+}
+
+resource "kubernetes_config_map" "logstash_conf" {
+  count = var.enable_splunk_logging ? 1 : 0
+  metadata {
+    name      = "logstash-config"
+    namespace = kubernetes_namespace.default_list["monitoring"].metadata[0].name
+  }
+
+  data = {
+    "logstash.yml" = local.ls_config_map_data
+  }
+
+}
+
+resource "kubernetes_config_map" "logstash_pipeline" {
+  count = var.enable_splunk_logging ? 1 : 0
+
+  metadata {
+    name      = "logstash-pipeline"
+    namespace = kubernetes_namespace.default_list["monitoring"].metadata[0].name
+  }
+
+  data = {
+    "pipeline.conf" = local.ls_pipeline_config_map
+  }
+
+}
+
+locals {
+  ls_config_map_data = file("${path.module}/config/logstash/logstash.yml.tmpl")
+  ls_pipeline_config_map = templatefile("${path.module}/config/logstash/pipeline.conf.tmpl", local.logstash_template_variable_map)
+#   ls_config_map_hash = sha1(local.ls_config_map_data)
+}
+
+resource "kubernetes_deployment" "logstash" {
+  count = var.enable_splunk_logging ? 1 : 0
+  metadata {
+    name      = "logstash"
+    namespace = kubernetes_namespace.default_list["monitoring"].metadata[0].name
+    labels = {
+      app = "logstash"
+    }
+  }
+
+  spec {
+    replicas = var.logstash_replica_count
+    selector {
+      match_labels = {
+        app = "logstash"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "logstash"
+        }
+      }
+
+      spec {
+        service_account_name = "logstash"
+
+        container {
+          name  = "logstash"
+          image = "${var.tsc_package_repo}:${var.logstash_image}-${var.logstash_version}"
+          security_context {
+              run_as_user  = 1000
+              run_as_group = 1000
+              capabilities {
+                drop = ["ALL"]
+              }
+              allow_privilege_escalation = false
+              privileged                 = false
+              run_as_non_root            = true
+              read_only_root_filesystem  = false
+              seccomp_profile {
+                type = "RuntimeDefault"
+              }
+          }    
+
+          resources {
+            limits = {
+              cpu    = "500m"
+              memory = "1Gi"
+            }
+            requests = {
+              cpu    = "200m"
+              memory = "512Mi"
+            }
+          }
+
+          env {
+            name  = "LS_JAVA_OPTS"
+            value = "-Xms512m -Xmx512m"
+          }
+
+          # Config mounts
+          volume_mount {
+            name       = "logstash-config"
+            mount_path = "/usr/share/logstash/config/logstash.yml"
+            sub_path   = "logstash.yml"
+          }
+
+          volume_mount {
+            name       = "logstash-pipeline"
+            mount_path = "/usr/share/logstash/pipeline/logstash.conf"
+            sub_path   = "pipeline.conf"
+          }
+
+          # 🔑 Kubernetes container logs
+          volume_mount {
+            name       = "varlogcontainers"
+            mount_path = "/var/log/containers"
+            read_only  = true
+          }
+
+          volume_mount {
+            name       = "varlogpods"
+            mount_path = "/var/log/pods"
+            read_only  = true
+          }
+
+          volume_mount {
+            name       = "log-data"
+            mount_path = "/usr/share/logstash/log-data"
+          }
+        }
+
+        # Volumes
+        volume {
+          name = "logstash-config"
+
+          config_map {
+            name = "logstash-config"
+          }
+        }
+
+        volume {
+          name = "logstash-pipeline"
+
+          config_map {
+            name = "logstash-pipeline"
+          }
+        }
+
+        # 🔑 Required for Kubernetes logs
+        volume {
+          name = "varlogcontainers"
+
+          host_path {
+            path = "/var/log/containers"
+          }
+        }
+
+        volume {
+          name = "log-data"
+          host_path {
+            path = "/var/lib/log-data"
+            type = "DirectoryOrCreate"
+          }
+        }
+
+        volume {
+          name = "varlogpods"
+
+          host_path {
+            path = "/var/log/pods"
+          }
+        }
+
+        toleration {
+          operator = "Exists"
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "logstash" {
+  count = var.enable_splunk_logging ? 1 : 0
+  metadata {
+    name      = "logstash"
+    namespace = kubernetes_namespace.default_list["monitoring"].metadata[0].name
+    labels = {
+      app = "logstash"
+    }
+  }
+
+  spec {
+    selector = {
+      app = "logstash"
+    }
+
+    port {
+      name        = "beats"
+      port        = 5044        # Service port
+      target_port = 5044        # Container port
+      protocol    = "TCP"
+    }
+
+    type = "ClusterIP"
+  }
+}

--- a/cluster/terraform_kubernetes/logstash.tf
+++ b/cluster/terraform_kubernetes/logstash.tf
@@ -47,9 +47,9 @@ resource "kubernetes_config_map" "logstash_pipeline" {
 }
 
 locals {
-  ls_config_map_data = file("${path.module}/config/logstash/logstash.yml.tmpl")
+  ls_config_map_data     = file("${path.module}/config/logstash/logstash.yml.tmpl")
   ls_pipeline_config_map = templatefile("${path.module}/config/logstash/pipeline.conf.tmpl", local.logstash_template_variable_map)
-#   ls_config_map_hash = sha1(local.ls_config_map_data)
+  #   ls_config_map_hash = sha1(local.ls_config_map_data)
 }
 
 resource "kubernetes_deployment" "logstash" {
@@ -84,19 +84,19 @@ resource "kubernetes_deployment" "logstash" {
           name  = "logstash"
           image = "${var.tsc_package_repo}:${var.logstash_image}-${var.logstash_version}"
           security_context {
-              run_as_user  = 1000
-              run_as_group = 1000
-              capabilities {
-                drop = ["ALL"]
-              }
-              allow_privilege_escalation = false
-              privileged                 = false
-              run_as_non_root            = true
-              read_only_root_filesystem  = false
-              seccomp_profile {
-                type = "RuntimeDefault"
-              }
-          }    
+            run_as_user  = 1000
+            run_as_group = 1000
+            capabilities {
+              drop = ["ALL"]
+            }
+            allow_privilege_escalation = false
+            privileged                 = false
+            run_as_non_root            = true
+            read_only_root_filesystem  = false
+            seccomp_profile {
+              type = "RuntimeDefault"
+            }
+          }
 
           resources {
             limits = {
@@ -213,8 +213,8 @@ resource "kubernetes_service" "logstash" {
 
     port {
       name        = "beats"
-      port        = 5044        # Service port
-      target_port = 5044        # Container port
+      port        = 5044 # Service port
+      target_port = 5044 # Container port
       protocol    = "TCP"
     }
 

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -128,6 +128,26 @@ variable "enable_lowpriority_app" {
   default = false
 }
 
+variable "enable_splunk_logging" {
+  type = bool
+  default = false
+  description = "Enables logstash and filebeat for shipping logs to Splunk"
+}
+
+variable "logstash_version" {
+  type    = string
+  default = "8.19.9"
+}
+
+variable "logstash_image" {
+  type    = string
+  default = "logstash"
+}
+
+variable "logstash_replica_count" {
+  type    = number
+  default = 1
+}
 variable "grafana_app_cpu" {
   type    = string
   default = "500m"
@@ -400,6 +420,11 @@ locals {
 
   filebeats_template_variable_map = {
     BEATS_URL = data.azurerm_key_vault_secret.beats_url.value
+  }
+
+  logstash_template_variable_map = {
+    SPLUNK_EVENTS_URL = data.azurerm_key_vault_secret.splunk_events_url.value
+    SPLUNK_EVENTS_TOKEN = data.azurerm_key_vault_secret.splunk_events_token.value
   }
 
   cluster_sa_name = (var.environment == var.config ?

--- a/cluster/terraform_kubernetes/variables.tf
+++ b/cluster/terraform_kubernetes/variables.tf
@@ -129,8 +129,8 @@ variable "enable_lowpriority_app" {
 }
 
 variable "enable_splunk_logging" {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Enables logstash and filebeat for shipping logs to Splunk"
 }
 
@@ -423,7 +423,7 @@ locals {
   }
 
   logstash_template_variable_map = {
-    SPLUNK_EVENTS_URL = data.azurerm_key_vault_secret.splunk_events_url.value
+    SPLUNK_EVENTS_URL   = data.azurerm_key_vault_secret.splunk_events_url.value
     SPLUNK_EVENTS_TOKEN = data.azurerm_key_vault_secret.splunk_events_token.value
   }
 

--- a/cluster/terraform_kubernetes/welcome_app.tf
+++ b/cluster/terraform_kubernetes/welcome_app.tf
@@ -18,6 +18,7 @@ resource "kubernetes_deployment" "welcome_app" {
         annotations = {
           "logit.io/send"        = "true"
           "fluentbit.io/exclude" = "true"
+          "splunk/send"          = "true"
         }
       }
       spec {


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
To enable sending logs to DFE Splunk the addition of a second Filebeat and a Logstash to forward the logs to DFE Splunk. This PR will deploy the Filebeat and Logstash to the test cluster, Splunk shipping can be turned on and off in environments by setting enable_splunk_logging = true this variable is defaulting to false.

## Changes proposed in this pull request
Adds a second Filebeat daemonset to the clusters that looks for splunk/send: "true" annotations and forwards logs from those pods to Logstash.
Adds Kubernetes deployment for Logstash along with service accounts and configmaps for Logstash configurations, adds a basic Logstash pipeline that receives data from the new Filebeat and forwards logs to DFE Splunk 
Creates kubernetes service for Logstash. 

## Guidance to review
Can be deployed to a dev cluster by pulling this branch and standing up a dev, enable_splunk_logging is set as true in the development tfvars. Observe that new Filebeat and Logstash resources are created. 

## Before merging


## After merging


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
