### PR TITLE
increased pod memory

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -73,7 +73,7 @@
   "enable_lowpriority_app": true,
   "prometheus_app_mem": "14Gi",
   "prometheus_app_cpu": "0.5",
-  "thanos_querier_mem": "2Gi",
+  "thanos_querier_mem": "4Gi",
   "thanos_app_cpu": "0.5",
   "thanos_app_mem": "2Gi",
   "thanos_compactor_mem": "7Gi",


### PR DESCRIPTION
## Context
Bug fix - increase memory for pod due to OOM errors

## Changes proposed in this pull request
This PR will double the memory for the thanos querier pod in production from 2gb to 4gb, to address out-of-memory errors.

## Guidance to review
Review code changes and run a TF plan to confirm the pod memory is being increased from 2gb to 4gb.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
