### PR TITLE
2911 postgres backup via aks

### DIFF
--- a/.github/workflows/build-postgres-backup-image.yml
+++ b/.github/workflows/build-postgres-backup-image.yml
@@ -1,0 +1,47 @@
+name: Build DB Backup Image
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 12 * * 0"
+    #Will run once a week on Sunday afternoon
+
+permissions:
+  packages: write
+  contents: write
+  id-token: write
+  pull-requests: write
+
+env:
+  DOCKER_IMAGE: ghcr.io/dfe-digital/teacher-services-cloud-db-backup
+
+jobs:
+  build-no-cache:
+    outputs:
+      docker-image-tag: ${{ steps.build-image.outputs.tag }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build DB Backup Image
+        id: build-db-backup-image
+        uses: DFE-Digital/github-actions/build-docker-image@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          dockerfile-path: images/postgres-backup/Dockerfile
+          context: images/postgres-backup
+          reuse-cache: true
+          snyk-token: ${{ secrets.SNYK_TOKEN }}
+          max-cache: false
+          docker-repository: ${{ env.DOCKER_IMAGE }}
+
+      - name: Notify teams channel on job failure
+        if: ${{ failure() }}
+        uses: DFE-Digital/github-actions/send-to-teams-channel@master
+        with:
+          teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          title: "Build failure"
+          service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
+          message: |
+            Rebuild docker cache failure

--- a/.github/workflows/deploy-cluster.yml
+++ b/.github/workflows/deploy-cluster.yml
@@ -25,6 +25,7 @@ on:
       - 'scripts/**'
       - 'templates/**'
       - 'alerting/**'
+      - 'images/**'
 
 jobs:
   validate-terraform:

--- a/images/postgres-backup/Dockerfile
+++ b/images/postgres-backup/Dockerfile
@@ -1,0 +1,29 @@
+# ------------------------------
+# Stage 1: Download AzCopy
+# ------------------------------
+FROM alpine:3.24.1  AS azcopy-builder
+
+RUN apk add --no-cache curl tar
+
+RUN curl -sSL https://aka.ms/downloadazcopy-v10-linux | tar -xz && \
+    cp ./azcopy_linux_amd64_*/azcopy /azcopy
+
+# ------------------------------
+# Stage 2: Runtime
+# ------------------------------
+FROM alpine:3.24.1
+
+RUN apk add --no-cache \
+    postgresql17-client \
+    bash \
+    ca-certificates \
+    gcompat
+
+COPY --from=azcopy-builder /azcopy /usr/local/bin/azcopy
+
+RUN chmod +x /usr/local/bin/azcopy && \
+    adduser -D -u 10001 pgbackup
+
+USER pgbackup
+
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
## Context
This change introduces a basic image which can be used by services to run Postgres commands and use AzCopy for DB related backup \ restore operations, allowing these operations to happen within the Azure and AKS infrastrcuture.

https://trello.com/c/vZdF0ehL/2911-att-postgres-backup-via-aks-job

## Changes proposed in this pull request
- Add new Dockerfile to produce a minaimal image with
  - Postgres 17 Client
  - AzCopy
- A schedule workflow to build this image weekly
- Excludes the images folder containing the Docker file from triggering cluster deploy workflows

## Guidance to review
View the manually triggered image build (workflow name has since been updated to more appropriate value): https://github.com/DFE-Digital/teacher-services-cloud/actions/runs/31495505602

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
