### PR TITLE
Traefik servicing requests in the test cluster

### DIFF
--- a/.github/workflows/deploy-cluster.yml
+++ b/.github/workflows/deploy-cluster.yml
@@ -147,7 +147,8 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: [development, production]
+        environment: [development]
+        #environment: [development, production]
     permissions:
       id-token: write # Required for OIDC authentication to Azure
 

--- a/cluster/terraform_kubernetes/config/test.tfvars.json
+++ b/cluster/terraform_kubernetes/config/test.tfvars.json
@@ -54,7 +54,7 @@
   "statuscake_alerts": {
     "tscluster-test": {
       "website_name": "Teacher-Services-AKS-Cluster-TEST",
-      "website_url": "https://status.test.teacherservices.cloud/healthz",
+      "website_url": "https://www.test.teacherservices.cloud/",
       "check_rate": 60,
       "contact_group": [
         282453
@@ -63,7 +63,7 @@
   },
   "statuscake_ssl_alerts": {
     "tscluster-test-ssl": {
-      "website_url": "https://status.test.teacherservices.cloud/healthz",
+      "website_url": "https://www.test.teacherservices.cloud/",
       "check_rate": 3600,
       "contact_group": [
         282453

--- a/cluster/terraform_kubernetes/config/traefik/test.values.yaml
+++ b/cluster/terraform_kubernetes/config/traefik/test.values.yaml
@@ -18,7 +18,7 @@ providers:
     #watchNamespaceSelector: "traefik-watch=true"
     publishService:
       # -- Service fronting the Ingress controller. Takes the form 'namespace/name'
-      enabled: false
+      enabled: true
     proxyBodySize: 52428800
     proxyBufferSize: 24576
     upstreamKeepaliveTimeout: 120


### PR DESCRIPTION
## Context
Set traefik to service requests alongside nginx in the Test cluster

## Changes proposed in this pull request
Enable traefik to publish services
Remove production from the dns-apply as the terraform module can't handle multiple addresses, and that will be set manually at the same time

## Guidance to review
make test terraform-kubernetes-plan

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
