### PR TITLE
Updated ARM_TEMPLATE_TAG to latest release

### DIFF
--- a/templates/new_service/Makefile
+++ b/templates/new_service/Makefile
@@ -1,4 +1,4 @@
-ARM_TEMPLATE_TAG=1.1.10
+ARM_TEMPLATE_TAG=1.1.16
 RG_TAGS={"Product" : "Teacher services cloud", "Service Offering" : "Teacher services cloud"}
 REGION=UK South
 SERVICE_NAME=#SERVICE_NAME#


### PR DESCRIPTION
## Context
Bugfix to resolve issue with ARM resource deployments during service onboarding.

## Changes proposed in this pull request
Template makefile for new services is updated from version 1.1.10 to 1.1.16, which is the latest release.
This release was to resolve a previous issue where resources couldn't be deployed because the URL to pull down config files from tra-shared-services contained a reference to a feature branch that had been merged, so the download would fail.

The makefile commands and parameters in tra-shared services were updated to avoid hardcoding, and allow existing services to continue accessing the release they were deployed with, to avoid any unexpected changes or errors.

This was tested and confirmed to have resolved the issue, however, the default arm tag version in the template makefile was left at version 1.1.10, leading to a mismatch between the parameters being passed to tra-shared-services and the release it was referencing. By updating the version, this will align the parameters in the makefile commands with the correct release of tra-shared-services. This has already been tested and resolved the issue, as it was discovered during a service onboarding.

Previous PRs for this change for more context:
https://github.com/DFE-Digital/tra-shared-services/pull/43
https://github.com/DFE-Digital/teacher-services-cloud/pull/637

## Guidance to review
Confirm that the release of tra-shared-services that matches the version of ARM_TEMPLATE_TAG (1.1.16) adds the templateVersion parameter to the json files being referenced by the makefile:
https://github.com/DFE-Digital/tra-shared-services/compare/1.1.15...1.1.16

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
