### PR TITLE
2788 - Tidy up stale konduit deployments

### DIFF
--- a/.github/workflows/konduit-app-reconcile.yml
+++ b/.github/workflows/konduit-app-reconcile.yml
@@ -1,0 +1,94 @@
+name: Reconcile Konduit Deployments
+
+on:
+  workflow_dispatch:
+    inputs:
+      cluster:
+        description: Cluster to run against
+        type: choice
+        required: true
+        default: all
+        options:
+          - all
+          - s189t01-tsc-platform-test-aks
+          - s189t01-tsc-test-aks
+          - s189p01-tsc-production-aks
+
+      dry_run:
+        description: Only display stale deployments
+        required: true
+        default: true
+        type: boolean
+
+  schedule:
+    - cron: "0 2 * * *"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  find-and-delete-stale-konduit-deployments:
+    runs-on: ubuntu-latest
+
+    outputs:
+      stale_deployments: ${{ steps.reconcile.outputs.stale_deployments }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cluster: s189t01-tsc-platform-test-aks
+            environment: platform-test
+          - cluster: s189t01-tsc-test-aks
+            environment: test
+          - cluster: s189p01-tsc-production-aks
+            environment: production
+
+    environment: ${{ matrix.environment }}
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Get stale Konduit Deployments
+        if: >
+          github.event_name == 'schedule' ||
+          github.event.inputs.cluster == 'all' ||
+          github.event.inputs.cluster == matrix.cluster
+        id: reconcile
+        uses: DFE-Digital/github-actions/konduit-app-reconcile@master
+        with:
+          cluster: ${{ matrix.cluster }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          age-hours: 48
+
+      - name: Report stale konduit deployments
+        if: steps.reconcile.conclusion == 'success'
+        run: |
+          echo '${{ steps.reconcile.outputs.stale_deployments }}'
+
+      - name: Delete stale konduit deployments
+        env:
+          DEPLOYMENTS: ${{ steps.reconcile.outputs.stale_deployments }}
+
+        if: >
+          steps.reconcile.conclusion == 'success' &&
+          (
+            github.event_name == 'schedule' ||
+            github.event.inputs.dry_run != 'true'
+          )
+        run: |
+          echo "$DEPLOYMENTS" | jq -c '.[]' | while read deployment; do
+            name=$(echo "$deployment" | jq -r '.name')
+            namespace=$(echo "$deployment" | jq -r '.namespace')
+            echo "Deleting $name from $namespace"
+            kubectl delete deployment "$name" -n "$namespace"
+          done
+
+      - name: Dry run message
+        if: >
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.dry_run == true
+        run: |
+          echo "This is a dry run so no deployments have been deleted"


### PR DESCRIPTION
## Context

We seem to get a lot of rogue konduit deployments, especially from the sip namespaces and we want tidy them up daily by deleting deployments older than 48 hours.

https://trello.com/c/KOjapE3J/2788-konduit-housekeeping

## Changes proposed in this pull request

A new workflow that references DFE-Digital/github-actions/konduit-app-reconcile and provides a way to delete deployments for konduit-app that are older than 48 hours. You can also run it manually to delete deployments in all clusters or a specific cluster and you can also carry out a dry run that just reports what it would delete.

## Guidance to review

I've created a test [branch ](2788-konduit-housekeeping-test) that runs on a push. From this you can see the deployments and the deployments that are skipped and not deleted.
You can alter the specific deployment and namespace to confirm that a deployment would be deleted by changing the values on line 75 of the test branch code.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card