### PR TITLE
enables sending logs to splunk from production cluster.

### DIFF
--- a/cluster/terraform_kubernetes/config/production.tfvars.json
+++ b/cluster/terraform_kubernetes/config/production.tfvars.json
@@ -80,6 +80,7 @@
   "thanos_compactor_disk": 512,
   "thanos_store_mem": "5Gi",
   "cluster_short": "pd",
+  "enable_splunk_logging": true,
   "alertmanager_teams_receiver_list": [
     "TEAMS_WEBHOOK_INFRA",
     "TEAMS_WEBHOOK_GSE",

--- a/cluster/terraform_kubernetes/config/traefik/test.values.yaml
+++ b/cluster/terraform_kubernetes/config/traefik/test.values.yaml
@@ -76,6 +76,7 @@ deployment:
     # prometheus.io/scrape: "true"
     # prometheus.io/path: "/metrics"
     logit.io/send: "true"
+    splunk/send: "true"
     fluentbit.io/exclude: "true"
 
   # readinessPath: "/ping"


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
This PR will enable sending of logs from from the production AKS cluster to the DFE splunk instances. Also adds the annotation for enabling Splunk to the test Traefik  

## Changes proposed in this pull request
Sets enable_splunk_logging: true for the production cluster
Adds splunk/send: "true" to the test values for Traefik 

## Guidance to review
Has been tested with a Dev cluster and is currently running in test

## Before merging
<!-- Any extra steps like: delete temp commit, send warning, wait after office hours... -->

## After merging
<!-- Any extra steps like: update other PR, apply manually, inform someone... -->

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
