### PR TITLE
Added write permissions to workflow

### DIFF
--- a/templates/new_service/.github/workflows/build-nocache.yml
+++ b/templates/new_service/.github/workflows/build-nocache.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build-no-cache:
+    permissions:
+      packages: write
     env:
       DOCKER_REPOSITORY: #DOCKER_REPOSITORY#
     outputs:


### PR DESCRIPTION
## Context
build-no-cache fails without write package permission, this PR adds it into the template for new services

## Changes proposed in this pull request
add write package permission to build-nocache template

## Guidance to review
Check code changes and confirm it matches the changes applied to other services such as https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/3347/changes

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
