### PR TITLE
Correct path for alert triggers

### DIFF
--- a/alerting/terraform_logic_app/workflows/azure_alert_to_teams_notifications.json
+++ b/alerting/terraform_logic_app/workflows/azure_alert_to_teams_notifications.json
@@ -280,7 +280,7 @@
                     {
                         "name": "alertTargetIDs",
                         "type": "array",
-                        "value": "@triggerBody()?['body']?['data']?['essentials']?['alertTargetIDs']"
+                        "value": "@triggerBody()?['data']?['essentials']?['alertTargetIDs']"
                     }
                 ]
             },


### PR DESCRIPTION
## Context
Bug Fix: incorrect assignment for alertTargetIDs variable

## Changes proposed in this pull request
Correct json path used to populate alertTargetIDs

## Guidance to review
Compare to working variables.

Review output from updated logic app [instance](https://portal.azure.com/#view/Microsoft_Azure_EMA/DesignerEditorConsumption.ReactView/id/%2Fsubscriptions%2F5c83eb53-a94f-4778-b258-1f33efe49655%2FresourceGroups%2Fs189d01-tsc-mn-rg%2Fproviders%2FMicrosoft.Logic%2Fworkflows%2Fs189d01-tsc-teams-alerts-rdg/location/uksouth/isReadOnly~/false), ensure Affected Resouce has a value when alerts are fired:
Current:
<img width="682" height="280" alt="image" src="https://github.com/user-attachments/assets/c9a13b34-84de-4c4a-bebf-81f8344cf062" />
Expected:
<img width="842" height="761" alt="image" src="https://github.com/user-attachments/assets/f4c872a4-509c-47c4-afad-b87d111c3c86" />

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
