### PR TITLE
2950 - Adds sku_tier variable and sets Standard

### DIFF
--- a/cluster/terraform_aks_cluster/config/test.tfvars.json
+++ b/cluster/terraform_aks_cluster/config/test.tfvars.json
@@ -1,6 +1,8 @@
 {
   "cip_tenant": true,
   "kubernetes_version": "1.35.5",
+  "sku_tier": "Standard",
+  "clone_sku_tier": "Free",
   "default_node_pool": {
     "node_count": 2,
     "orchestrator_version": "1.35.5",

--- a/cluster/terraform_aks_cluster/main.tf
+++ b/cluster/terraform_aks_cluster/main.tf
@@ -14,6 +14,7 @@ resource "azurerm_kubernetes_cluster" "main" {
   node_resource_group       = local.node_resource_group_name
   dns_prefix                = local.dns_prefix
   kubernetes_version        = var.kubernetes_version
+  sku_tier                  = var.sku_tier
   oidc_issuer_enabled       = true
   workload_identity_enabled = true
 
@@ -122,6 +123,7 @@ resource "azurerm_kubernetes_cluster" "clone" {
   node_resource_group       = local.clone_node_resource_group_name
   dns_prefix                = "${azurerm_kubernetes_cluster.main.dns_prefix}-clone"
   kubernetes_version        = azurerm_kubernetes_cluster.main.kubernetes_version
+  sku_tier                  = var.clone_sku_tier
   oidc_issuer_enabled       = true
   workload_identity_enabled = true
 

--- a/cluster/terraform_aks_cluster/variables.tf
+++ b/cluster/terraform_aks_cluster/variables.tf
@@ -19,6 +19,14 @@ variable "cip_tenant" { type = bool }
 variable "default_node_pool" { type = map(any) }
 variable "node_pools" { type = any }
 variable "kubernetes_version" { type = string }
+variable "sku_tier" {
+  type    = string
+  default = "Free"
+}
+variable "clone_sku_tier" {
+  type    = string
+  default = "Free"
+}
 variable "clone_cluster" {
   type    = bool
   default = false


### PR DESCRIPTION
## Context

It has been determined that we require the SLA that comes with the Standard AKS cluster tier. Therefore, a non-destructive upgrade from the Free tier is to be applied in test.

## Changes proposed in this pull request

New `sku_tier` (default set to "Free" for safety's sake, although it does do this implicitly) and `clone_sku_tier` variables have been added to the code base. Confirmed with Richard M that no clone clusters are deployed, but that it should remain on the free tier for potential future use.

Standard tier has been applied to the sku_tier attribute.

## Guidance to review

I have run an apply in Test and confirmed that the only changes are as follows:

```
Terraform will perform the following actions:

  # azurerm_kubernetes_cluster.main will be updated in-place
  ~ resource "azurerm_kubernetes_cluster" "main" {
        id                                  = "/subscriptions/********-****-****-****-************/resourceGroups/s189t01-tsc-ts-rg/providers/Microsoft.ContainerService/managedClusters/s189t01-tsc-test-aks"
        name                                = "s189t01-tsc-test-aks"
      ~ sku_tier                            = "Free" -> "Standard"
        tags                                = {
            "Environment"      = "Test"
            "Product"          = "Teacher services cloud"
            "Service Offering" = null
        }
        # (38 unchanged attributes hidden)

        # (9 unchanged blocks hidden)
    }

  # azurerm_subnet.backing-service-subnets["postgres-snet"] will be updated in-place
  ~ resource "azurerm_subnet" "backing-service-subnets" {
        id                                            = "/subscriptions/********-****-****-****-************/resourceGroups/s189t01-tsc-ts-rg/providers/Microsoft.Network/virtualNetworks/s189t01-tsc-test-vnet/subnets/postgres-snet"
        name                                          = "postgres-snet"
      ~ service_endpoints                             = [
          - "Microsoft.Storage",
        ]
        # (8 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
